### PR TITLE
ScormInstance and SCORMCourseMetadata Models

### DIFF
--- a/src/models/courses/ScormInstance.js
+++ b/src/models/courses/ScormInstance.js
@@ -1,0 +1,23 @@
+import { model, COMMON_PREFIX } from '../Registry';
+
+import Instance from './Instance';
+
+export default
+@model
+class ScormInstance extends Instance {
+	static MimeType = [
+		COMMON_PREFIX + 'courses.scormcourseinstance',
+	]
+	
+	static Fields = {
+		...Instance.Fields,
+		Metadata: { type: 'model' }
+	}
+
+	isScormInstance = true;
+
+	async getScormCourse () {
+		const scormLink = await this.Metadata.getLink('LaunchSCORM');
+		return scormLink;
+	}
+}

--- a/src/models/courses/index.js
+++ b/src/models/courses/index.js
@@ -1,5 +1,6 @@
 export * as activity from './activity';
 export * as overview from './overview';
+export * as scorm from './scorm';
 
 export Grade from './Grade';
 export CourseDiscussion from './CourseDiscussion';
@@ -22,3 +23,4 @@ export Outline from './Outline';
 export OutlineNode from './OutlineNode';
 export OutlineNodeProgress from './OutlineNodeProgress';
 export RosterEnrollmentSummary from './RosterEnrollmentSummary';
+export ScormInstance from './ScormInstance';

--- a/src/models/courses/scorm/SCORMCourseMetadata.js
+++ b/src/models/courses/scorm/SCORMCourseMetadata.js
@@ -1,0 +1,15 @@
+import { model, COMMON_PREFIX } from '../../Registry';
+import Base from '../../Base';
+
+export default
+@model
+class SCORMCourseMetadata extends Base {
+	static MimeType = [
+		COMMON_PREFIX + 'courseware_scorm.scormcoursemetadata',
+	]
+
+	static Fields = {
+		...Base.Fields,
+		'scorm_id': { type: 'string', name: 'scormId' }
+	}
+}

--- a/src/models/courses/scorm/index.js
+++ b/src/models/courses/scorm/index.js
@@ -1,0 +1,2 @@
+
+export SCORMCourseMetadata from './SCORMCourseMetadata';


### PR DESCRIPTION
ScormInstance extends Course Instance. The course flag is isScormInstance to know in the platform if you are dealing with a scorm course instance. 

SCORMCourseMetadata is for the launch scorm links which live within the metadata field.