### PR TITLE
NTI-6823: Pass along parsed models to clone

### DIFF
--- a/src/mixins/Fields.js
+++ b/src/mixins/Fields.js
@@ -649,9 +649,12 @@ export function clone (obj) {
 	}
 
 	if (Object.getPrototypeOf(obj) !== Object.getPrototypeOf({})) {
-		if (obj[Parser]) {
-			throw new TypeError('Cannot clone model. Did you reparse a model?');
-		}
+		/**
+		 * We decided to pass models along.
+		 * They will be handeled in the applyModelField as a model and not be reparsed.
+		 * This was a problem when we passed parsed models and then reparsed them again.
+		 * Since we are no longer doing that this shouldn't be an issue.
+		 */
 
 		return obj;
 	}

--- a/src/mixins/__test__/Fields.spec.js
+++ b/src/mixins/__test__/Fields.spec.js
@@ -442,6 +442,9 @@ describe('Fields Mixin', () => {
 				static Fields = {
 					'Items': { type: 'model[]', defaultValue: [] },
 				}
+				constructor (data) {
+					this.initMixins(data);
+				}
 			}
 
 			class HighLight {
@@ -451,7 +454,8 @@ describe('Fields Mixin', () => {
 			}
 
 			const Items = [new HighLight({ fieldA: 'test 1' }), new HighLight({ fieldA: 'test 2' })];
-			expect(() => clone(new Foo({ Items }))).toThrowErrorMatchingSnapshot();
+			const clonedFoo = clone(new Foo({ Items }));
+			expect(clonedFoo.Items).toEqual(Items);
 		});
 	});
 

--- a/src/mixins/__test__/__snapshots__/Fields.spec.js.snap
+++ b/src/mixins/__test__/__snapshots__/Fields.spec.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Fields Mixin Clone Cases Throw Error: Parse Twice 1`] = `"Cannot clone model. Did you reparse a model?"`;


### PR DESCRIPTION
We now handle parsed models by not re-parsing them again. The unit test has been updated to expect this change in clone.

This card is a good example of models being created from the get go with highlights.