### PR TITLE
these need to be encoded as components also.

### DIFF
--- a/src/models/content/BundleSearchDataSource.js
+++ b/src/models/content/BundleSearchDataSource.js
@@ -23,9 +23,7 @@ export default class BundleSearchDataSource extends PagedDataSource {
 			sortOn: 'relevance'
 		};
 
-		const href = path.join(this.service.getUserUnifiedSearchURL(),
-							   encodeURIComponent(rootPackage.NTIID),
-							   encodeURIComponent(term));
+		const href = path.join(this.service.getUserUnifiedSearchURL(), encodeURIComponent(rootPackage.NTIID), encodeURIComponent(term));
 
 		const contents = await this.service.get(URL.appendQueryParams(href, requestParams));
 


### PR DESCRIPTION
Similar to [nti.web.app#517](https://github.com/NextThought/nti.web.app/pull/517)