### PR TITLE
drop decorator syntax

### DIFF
--- a/src/models/AnalyticsSession.js
+++ b/src/models/AnalyticsSession.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from './Registry';
 import Base from './Base';
 
-export default
-@model
 class AnalyticsSession extends Base {
 	static MimeType = COMMON_PREFIX + 'analytics.analyticssession'
 
@@ -19,3 +19,5 @@ class AnalyticsSession extends Base {
 	getSessionStartTime () {} //implemented by SessionStartTime date field.
 	getSessionEndTime () {} //implemented by SessionEndTime date field.
 }
+
+export default decorate(AnalyticsSession, {with: [model]});

--- a/src/models/Base.js
+++ b/src/models/Base.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 import Logger from '@nti/util-logger';
 
@@ -23,9 +24,6 @@ const PHANTOM = Symbol.for('Phantom');
 const is = Symbol('isTest');
 
 
-export default
-@model
-@mixin(HasLinks, JSONValue, Editable, Pendability, Fields)
 class Base extends EventEmitter {
 	static MimeType = '__base__'
 
@@ -109,7 +107,7 @@ class Base extends EventEmitter {
 
 
 	getEventPrefix () { return this.OID; }
-	
+
 	onChange (who) {
 		this.emit('change', this, who);
 
@@ -257,3 +255,8 @@ class Base extends EventEmitter {
 		return !attr || Object.prototype.hasOwnProperty.call(u,attr) || attr === status || (/everyone/i).test(attr);
 	}
 }
+
+export default decorate(Base, { with: [
+	model,
+	mixin(HasLinks, JSONValue, Editable, Pendability, Fields)
+]});

--- a/src/models/Change.js
+++ b/src/models/Change.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from './Registry';
 import Base from './Base';
 
-export default
-@model
 class Change extends Base {
 	static MimeType = COMMON_PREFIX + 'change'
 
@@ -12,3 +12,5 @@ class Change extends Base {
 	}
 
 }
+
+export default decorate(Change, { with: [model]});

--- a/src/models/Registry.js
+++ b/src/models/Registry.js
@@ -111,7 +111,7 @@ export default class Registry {
 		}
 
 		if (!map.has(existingType)) {
-			throw new TypeError('Cannot alias a non-existing type');
+			throw new TypeError(`Cannot alias a non-existing type (${existingType})`);
 		}
 
 		if (map.has(alias)) {

--- a/src/models/Workspace.js
+++ b/src/models/Workspace.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from './Registry';
 import Base from './Base';
 import Collection from './WorkspaceCollection';
 
-export default
-@model
 class Workspace extends Base {
 	static MimeType = COMMON_PREFIX + 'workspace'
 
@@ -18,3 +18,5 @@ class Workspace extends Base {
 	}
 
 }
+
+export default decorate(Workspace, { with: [model]});

--- a/src/models/anchors/ContentPointer.js
+++ b/src/models/anchors/ContentPointer.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Base from './Base';
 
-export default
-@model
 class ContentPointer extends Base {
 	static MimeType = COMMON_PREFIX + 'contentrange.contentpointer'
 
@@ -12,3 +12,5 @@ class ContentPointer extends Base {
 		'Class': { type: 'string' }
 	}
 }
+
+export default decorate(ContentPointer, { with: [model]});

--- a/src/models/anchors/ContentRangeDescription.js
+++ b/src/models/anchors/ContentRangeDescription.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Base from './Base';
 
-export default
-@model
 class ContentRangeDescription extends Base {
 	static MimeType = COMMON_PREFIX + 'contentrange.contentrangedescription'
 
@@ -31,3 +31,5 @@ class ContentRangeDescription extends Base {
 		return this[this.locatorKey()];
 	}
 }
+
+export default decorate(ContentRangeDescription, { with: [model]});

--- a/src/models/anchors/DomContentPointer.js
+++ b/src/models/anchors/DomContentPointer.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import ContentPointer from './ContentPointer';
@@ -8,8 +10,6 @@ const VALID_ROLES = [
 	'ancestor'
 ];
 
-export default
-@model
 class DomContentPointer extends ContentPointer {
 	static MimeType = COMMON_PREFIX + 'contentrange.domcontentpointer'
 
@@ -41,3 +41,5 @@ class DomContentPointer extends ContentPointer {
 		return {confidence: 0, node: null};
 	}
 }
+
+export default decorate(DomContentPointer, {with: [model]});

--- a/src/models/anchors/DomContentRangeDescription.js
+++ b/src/models/anchors/DomContentRangeDescription.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import ContentRangeDescription from './ContentRangeDescription';
 import DomContentPointer from './DomContentPointer';
 
-export default
-@model
 class DomContentRangeDescription extends ContentRangeDescription {
 	static MimeType = COMMON_PREFIX + 'contentrange.domcontentrangedescription'
 
@@ -44,3 +44,5 @@ class DomContentRangeDescription extends ContentRangeDescription {
 		return (o && o instanceof DomContentPointer);
 	}
 }
+
+export default decorate(DomContentRangeDescription, {with: [model]});

--- a/src/models/anchors/ElementDomContentPointer.js
+++ b/src/models/anchors/ElementDomContentPointer.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import DomContentPointer from './DomContentPointer';
 
-export default
-@model
 class ElementDomContentPointer extends DomContentPointer {
 	static MimeType = COMMON_PREFIX + 'contentrange.elementdomcontentpointer'
 
@@ -58,3 +58,5 @@ class ElementDomContentPointer extends DomContentPointer {
 		return AnchorLib.locateElementDomContentPointer(this, ancestorNode, startResult);
 	}
 }
+
+export default decorate(ElementDomContentPointer, {with: [model]});

--- a/src/models/anchors/TextContext.js
+++ b/src/models/anchors/TextContext.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Base from './Base';
 
-export default
-@model
 class TextContext extends Base {
 	static MimeType = COMMON_PREFIX + 'contentrange.textcontext'
 
@@ -43,3 +43,5 @@ class TextContext extends Base {
 		}
 	}
 }
+
+export default decorate(TextContext, {with: [model]});

--- a/src/models/anchors/TextDomContentPointer.js
+++ b/src/models/anchors/TextDomContentPointer.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import DomContentPointer from './DomContentPointer';
 import ElementDomContentPointer from './ElementDomContentPointer';
 
-export default
-@model
 class TextDomContentPointer extends DomContentPointer {
 	static MimeType = COMMON_PREFIX + 'contentrange.textdomcontentpointer'
 
@@ -72,3 +72,5 @@ class TextDomContentPointer extends DomContentPointer {
 		return AnchorLib.locateRangeEdgeForAnchor(this, ancestorNode, startResult);
 	}
 }
+
+export default decorate(TextDomContentPointer, {with: [model]});

--- a/src/models/anchors/TimeContentPointer.js
+++ b/src/models/anchors/TimeContentPointer.js
@@ -1,11 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import ContentPointer from './ContentPointer';
 
 const VALID_ROLES = ['start', 'end'];
 
-export default
-@model
 class TimeContentPointer extends ContentPointer {
 	static MimeType = COMMON_PREFIX + 'contentrange.timecontentpointer'
 
@@ -55,3 +55,5 @@ class TimeContentPointer extends ContentPointer {
 		}
 	}
 }
+
+export default decorate(TimeContentPointer, {with:[model]});

--- a/src/models/anchors/TimeRangeDescription.js
+++ b/src/models/anchors/TimeRangeDescription.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import ContentRangeDescription from './ContentRangeDescription';
 import TimeContentPointer from './TimeContentPointer';
 
-export default
-@model
 class TimeRangeDescription extends ContentRangeDescription {
 	static MimeType = COMMON_PREFIX + 'contentrange.timerangedescription'
 
@@ -36,3 +36,5 @@ class TimeRangeDescription extends ContentRangeDescription {
 		return Boolean(o && o instanceof TimeContentPointer);
 	}
 }
+
+export default decorate(TimeRangeDescription, {with: [model]});

--- a/src/models/anchors/TranscriptContentPointer.js
+++ b/src/models/anchors/TranscriptContentPointer.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import TimeContentPointer from './TimeContentPointer';
 
-export default
-@model
 class TranscriptContentPointer extends TimeContentPointer {
 	static MimeType = COMMON_PREFIX + 'contentrange.transcriptcontentpointer'
 
@@ -20,3 +20,5 @@ class TranscriptContentPointer extends TimeContentPointer {
 	getPointer () { return this.pointer; }
 	getCueId () { return this.cueid; }
 }
+
+export default decorate(TranscriptContentPointer, {with: [model]});

--- a/src/models/anchors/TranscriptRangeDescription.js
+++ b/src/models/anchors/TranscriptRangeDescription.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import TimeRangeDescription from './TimeRangeDescription';
 
-export default
-@model
 class TranscriptRangeDescription extends TimeRangeDescription {
 	static MimeType = COMMON_PREFIX + 'contentrange.transcriptrangedescription'
 }
+
+export default decorate(TranscriptRangeDescription, { with: [model]});

--- a/src/models/annotations/Annotation.js
+++ b/src/models/annotations/Annotation.js
@@ -1,11 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Service} from '../../constants';
 import Likable from '../../mixins/Likable';
 import Base from '../Base';
 
-export default
-@mixin(Likable)
 class Annotation extends Base {
 
 	static Fields = {
@@ -37,3 +36,5 @@ class Annotation extends Base {
 		return this[Service].getObject(this.getContainerID());
 	}
 }
+
+export default decorate(Annotation, {with:[mixin(Likable)]});

--- a/src/models/annotations/Bookmark.js
+++ b/src/models/annotations/Bookmark.js
@@ -1,9 +1,11 @@
+import { decorate } from '@nti/lib-commons';
+
 import { model, COMMON_PREFIX } from '../Registry';
 
 import Annotation from './Annotation';
 
-export default
-@model
 class Bookmark extends Annotation {
 	static MimeType = COMMON_PREFIX + 'bookmark';
 }
+
+export default decorate(Bookmark, { with: [model]});

--- a/src/models/annotations/Highlight.js
+++ b/src/models/annotations/Highlight.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Annotation from './Annotation';
 
-export default
-@model
 class Highlight extends Annotation {
 	static MimeType = COMMON_PREFIX + 'highlight'
 
@@ -12,3 +12,5 @@ class Highlight extends Annotation {
 		'selectedText': { type: 'string' },
 	}
 }
+
+export default decorate(Highlight, {with:[model]});

--- a/src/models/annotations/Note.js
+++ b/src/models/annotations/Note.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import Logger from '@nti/util-logger';
 import {mixin} from '@nti/lib-decorators';
 import {isNTIID} from '@nti/lib-ntiids';
@@ -14,9 +15,6 @@ import Highlight from './Highlight';
 const logger = Logger.get('models:annotations:Note');
 const UpdatedDiscussionCount = Symbol('Discussion Count');
 
-export default
-@model
-@mixin(Threadable, Flaggable, DiscussionInterface)
 class Note extends Highlight {
 	static MimeType = COMMON_PREFIX + 'note'
 
@@ -135,3 +133,8 @@ class Note extends Highlight {
 		return discussion;
 	}
 }
+
+export default decorate(Note, {with: [
+	model,
+	mixin(Threadable, Flaggable, DiscussionInterface),
+]});

--- a/src/models/annotations/Redaction.js
+++ b/src/models/annotations/Redaction.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Highlight from './Highlight';
 
-export default
-@model
 class Redaction extends Highlight {
 	static MimeType = COMMON_PREFIX + 'redaction'
 }
+
+export default decorate(Redaction, {with: [model]});

--- a/src/models/assessment/AssessedPart.js
+++ b/src/models/assessment/AssessedPart.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import assessed from '../../mixins/AssessedAssessmentPart';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(assessed)
 class AssessedPart extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.assessedpart'
 
@@ -37,3 +35,5 @@ class AssessedPart extends Base {
 		return typeof a === 'number' ? a === 1 : null;
 	}
 }
+
+export default decorate(AssessedPart, {with:[model, mixin(assessed)]});

--- a/src/models/assessment/AssessedQuestion.js
+++ b/src/models/assessment/AssessedQuestion.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import assessed from '../../mixins/AssessedAssessmentPart';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(assessed)
 class AssessedQuestion extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.assessedquestion'
 
@@ -41,3 +39,8 @@ class AssessedQuestion extends Base {
 		return true;
 	}
 }
+
+export default decorate(AssessedQuestion, {with: [
+	model,
+	mixin(assessed)
+]});

--- a/src/models/assessment/AssessedQuestionSet.js
+++ b/src/models/assessment/AssessedQuestionSet.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import assessed from '../../mixins/AssessedAssessmentPart';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(assessed)
 class AssessedQuestionSet extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.assessedquestionset'
 
@@ -56,3 +54,8 @@ class AssessedQuestionSet extends Base {
 		}
 	}
 }
+
+export default decorate(AssessedQuestionSet, {with:[
+	model,
+	mixin(assessed),
+]});

--- a/src/models/assessment/Hint.js
+++ b/src/models/assessment/Hint.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Mixin as HasContent} from '../../mixins/HasContent';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(HasContent)
 class Hint extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'assessment.hint',
@@ -19,3 +17,8 @@ class Hint extends Base {
 		'value': { type: 'string', content: true },
 	}
 }
+
+export default decorate(Hint, {with:[
+	model,
+	mixin(HasContent),
+]});

--- a/src/models/assessment/Part.js
+++ b/src/models/assessment/Part.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Mixin as HasContent, SetupContentProperties} from '../../mixins/HasContent';
@@ -9,9 +10,6 @@ import Base from '../Base';
 // Show Solutions if the part is answered & incorrect (as apposed to correct or 'unknown'), and there are solutions
 
 
-export default
-@model
-@mixin(HasContent)
 class Part extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.part'
 
@@ -107,3 +105,8 @@ class Part extends Base {
 		}
 	}
 }
+
+export default decorate(Part, {with: [
+	model,
+	mixin(HasContent),
+]});

--- a/src/models/assessment/Question.js
+++ b/src/models/assessment/Question.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import PlacementProvider from '../../authoring/placement/providers/Question';
@@ -13,9 +14,6 @@ import QuestionSubmission from './QuestionSubmission';
 
 const Individual = Symbol('Individual');
 
-export default
-@model
-@mixin(HasContent, SubmittableIdentity, QuestionIdentity)
 class Question extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'question',
@@ -143,3 +141,8 @@ class Question extends Base {
 	}
 
 }
+
+export default decorate(Question, {with: [
+	model,
+	mixin(HasContent, SubmittableIdentity, QuestionIdentity),
+]});

--- a/src/models/assessment/QuestionSet.js
+++ b/src/models/assessment/QuestionSet.js
@@ -1,4 +1,4 @@
-import {pluck} from '@nti/lib-commons';
+import {decorate, pluck} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import Completable from '../../mixins/Completable';
@@ -11,9 +11,6 @@ import QuestionSetSubmission from './QuestionSetSubmission';
 
 const SUBMITTED_TYPE = 'application/vnd.nextthought.assessment.assessedquestionset';
 
-export default
-@model
-@mixin(SubmittableIdentity, Completable)
 class QuestionSet extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'questionset',
@@ -185,3 +182,8 @@ class QuestionSet extends Base {
 		});
 	}
 }
+
+export default decorate(QuestionSet, {with: [
+	model,
+	mixin(SubmittableIdentity, Completable),
+]});

--- a/src/models/assessment/QuestionSetReference.js
+++ b/src/models/assessment/QuestionSetReference.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import Completable from '../../mixins/Completable';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(Completable)
 class QuestionSetReference extends Base {
 	static MimeType = COMMON_PREFIX + 'questionsetref'
 
@@ -26,3 +24,8 @@ class QuestionSetReference extends Base {
 		return this.target === id;
 	}
 }
+
+export default decorate(QuestionSetReference, {with:[
+	model,
+	mixin(Completable),
+]});

--- a/src/models/assessment/QuestionSetSubmission.js
+++ b/src/models/assessment/QuestionSetSubmission.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Service} from '../../constants';
@@ -5,9 +6,6 @@ import Submission from '../../mixins/Submission';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(Submission)
 class QuestionSetSubmission extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.questionsetsubmission'
 
@@ -52,3 +50,8 @@ class QuestionSetSubmission extends Base {
 			sum + (questionSet.getQuestion(q.getID()).isAnswered(q) ? 0 : 1), 0);
 	}
 }
+
+export default decorate(QuestionSetSubmission, {with:[
+	model,
+	mixin(Submission),
+]});

--- a/src/models/assessment/QuestionSubmission.js
+++ b/src/models/assessment/QuestionSubmission.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Service} from '../../constants';
@@ -5,9 +6,6 @@ import Submission from '../../mixins/Submission';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(Submission)
 class QuestionSubmission extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.questionsubmission'
 
@@ -70,3 +68,8 @@ class QuestionSubmission extends Base {
 		return (this.parts || []).filter(answered).length > 0;
 	}
 }
+
+export default decorate(QuestionSubmission, {with: [
+	model,
+	mixin(Submission),
+]});

--- a/src/models/assessment/Response.js
+++ b/src/models/assessment/Response.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class Response extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'assessment.response',
@@ -10,3 +10,5 @@ class Response extends Base {
 		COMMON_PREFIX + 'assessment.textresponse',
 	]
 }
+
+export default decorate(Response, {with:[model]});

--- a/src/models/assessment/Solution.js
+++ b/src/models/assessment/Solution.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class Solution extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.solution'
 
@@ -11,3 +11,5 @@ class Solution extends Base {
 		'value':                    { type: '*' }	// solution values can be various types
 	};
 }
+
+export default decorate(Solution, {with:[model]});

--- a/src/models/assessment/WordBank.js
+++ b/src/models/assessment/WordBank.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class WordBank extends Base {
 	static MimeType = COMMON_PREFIX + 'naqwordbank'
 
@@ -17,3 +17,4 @@ class WordBank extends Base {
 	}
 
 }
+export default decorate(WordBank, {with:[model]});

--- a/src/models/assessment/WordEntry.js
+++ b/src/models/assessment/WordEntry.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class WordEntry extends Base {
 	static MimeType = COMMON_PREFIX + 'naqwordentry'
 
@@ -12,3 +12,5 @@ class WordEntry extends Base {
 		'content': { type: 'string' }
 	};
 }
+
+export default decorate(WordEntry, {with:[model]});

--- a/src/models/assessment/assignment/Assignment.js
+++ b/src/models/assessment/assignment/Assignment.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import PlacementProvider from '../../../authoring/placement/providers/Assignment';
@@ -22,9 +23,6 @@ const isSummary = ({parts}) => parts && parts.some(x => x.IsSummary);
 const getAssociationCount = (x) => x.LessonContainerCount;
 const has = (x, k) => Object.prototype.hasOwnProperty.call(x, k);
 
-export default
-@model
-@mixin(Completable, Publishable, SubmittableIdentity, AssignmentIdentity)
 class Assignment extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.assignment'
 
@@ -405,3 +403,8 @@ class Assignment extends Base {
 			.then(() => this.onChange('all'));
 	}
 }
+
+export default decorate(Assignment, {with:[
+	model,
+	mixin(Completable, Publishable, SubmittableIdentity, AssignmentIdentity),
+]});

--- a/src/models/assessment/assignment/AssignmentFeedback.js
+++ b/src/models/assessment/assignment/AssignmentFeedback.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Service} from '../../../constants';
@@ -5,9 +6,6 @@ import names from '../../../mixins/CourseAndAssignmentNameResolving';
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
-@mixin(names)
 class AssignmentFeedback extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.userscourseassignmenthistoryitemfeedback'
 
@@ -44,3 +42,8 @@ class AssignmentFeedback extends Base {
 	}
 
 }
+
+export default decorate(AssignmentFeedback, {with:[
+	model,
+	mixin(names),
+]});

--- a/src/models/assessment/assignment/AssignmentFeedbackContainer.js
+++ b/src/models/assessment/assignment/AssignmentFeedbackContainer.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {Service} from '../../../constants';
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class AssignmentFeedbackContainer extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.userscourseassignmenthistoryitemfeedbackcontainer'
 
@@ -54,3 +54,5 @@ class AssignmentFeedbackContainer extends Base {
 		return (this.Items || []).map(fn);
 	}
 }
+
+export default decorate(AssignmentFeedbackContainer, {with:[model]});

--- a/src/models/assessment/assignment/AssignmentHistoryCollection.js
+++ b/src/models/assessment/assignment/AssignmentHistoryCollection.js
@@ -1,10 +1,8 @@
-import {pluck} from '@nti/lib-commons';
+import {decorate,pluck} from '@nti/lib-commons';
 
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class AssignmentHistoryCollection extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.userscourseassignmenthistory'
 
@@ -90,3 +88,5 @@ class AssignmentHistoryCollection extends Base {
 			.then(() => this.onChange('lastViewed'));
 	}
 }
+
+export default decorate(AssignmentHistoryCollection, {with:[model]});

--- a/src/models/assessment/assignment/AssignmentHistoryItem.js
+++ b/src/models/assessment/assignment/AssignmentHistoryItem.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class AssignmentHistoryItem extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'assessment.assignmenthistoryitem',
@@ -65,3 +65,5 @@ class AssignmentHistoryItem extends Base {
 	}
 
 }
+
+export default decorate(AssignmentHistoryItem, {with:[model]});

--- a/src/models/assessment/assignment/AssignmentHistoryItemContainer.js
+++ b/src/models/assessment/assignment/AssignmentHistoryItemContainer.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class AssignmentHistoryItemContainer extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.userscourseassignmenthistoryitemcontainer'
 
@@ -15,3 +15,5 @@ class AssignmentHistoryItemContainer extends Base {
 		return this.Items && this.Items[this.Items.length - 1];
 	}
 }
+
+export default decorate(AssignmentHistoryItemContainer, {with:[model]});

--- a/src/models/assessment/assignment/AssignmentHistoryItemSummary.js
+++ b/src/models/assessment/assignment/AssignmentHistoryItemSummary.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class AssignmentHistoryItemSummary extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'assessment.assignmenthistoryitemsummary',
@@ -23,3 +23,5 @@ class AssignmentHistoryItemSummary extends Base {
 		return this.getSubmissionCreatedTime();
 	}
 }
+
+export default decorate(AssignmentHistoryItemSummary, {with:[model]});

--- a/src/models/assessment/assignment/AssignmentMetadataItem.js
+++ b/src/models/assessment/assignment/AssignmentMetadataItem.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class AssignmentMetadataItem extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.userscourseassignmentmetadataitem'
 
@@ -22,3 +22,5 @@ class AssignmentMetadataItem extends Base {
 		return this.duration;
 	}
 }
+
+export default decorate(AssignmentMetadataItem, {with:[model]});

--- a/src/models/assessment/assignment/AssignmentPart.js
+++ b/src/models/assessment/assignment/AssignmentPart.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class AssignmentPart extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.assignmentpart'
 
@@ -43,3 +43,5 @@ class AssignmentPart extends Base {
 	}
 
 }
+
+export default decorate(AssignmentPart, {with:[model]});

--- a/src/models/assessment/assignment/AssignmentReference.js
+++ b/src/models/assessment/assignment/AssignmentReference.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import Completable from '../../../mixins/Completable';
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
-@mixin(Completable)
 class AssignmentReference extends Base {
 	static MimeType = COMMON_PREFIX + 'assignmentref'
 
@@ -25,3 +23,8 @@ class AssignmentReference extends Base {
 		return this['Target-NTIID'] === id;
 	}
 }
+
+export default decorate(AssignmentReference, {with:[
+	model,
+	mixin(Completable),
+]});

--- a/src/models/assessment/assignment/AssignmentSubmission.js
+++ b/src/models/assessment/assignment/AssignmentSubmission.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import Submission from '../../../mixins/Submission';
@@ -10,9 +11,6 @@ const RELS = {
 	HISTORY: 'History',
 };
 
-export default
-@model
-@mixin(Submission)
 class AssignmentSubmission extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'assessment.assignmentsubmission',
@@ -88,7 +86,7 @@ class AssignmentSubmission extends Base {
 		await p.refresh();
 		if (p.hasLink(RELS.HISTORY)) {
 			const history = await p.fetchLinkParsed(RELS.HISTORY);
-	
+
 			if(history && history.MetadataAttemptItem && history.MetadataAttemptItem.hasLink(RELS.ASSIGNMENT)) {
 				const newAssignmentData = await history.MetadataAttemptItem.fetchLink(RELS.ASSIGNMENT);
 				await p.refresh(newAssignmentData);
@@ -99,3 +97,8 @@ class AssignmentSubmission extends Base {
 		return p;
 	}
 }
+
+export default decorate(AssignmentSubmission, {with: [
+	model,
+	mixin(Submission),
+]});

--- a/src/models/assessment/assignment/Collection.js
+++ b/src/models/assessment/assignment/Collection.js
@@ -5,6 +5,7 @@
  * non-assignment assessment object.  We also have a reference to all the
  * assignments that we can currently see.
  */
+import {decorate} from '@nti/lib-commons';
 import Logger from '@nti/util-logger';
 import {mixin} from '@nti/lib-decorators';
 
@@ -75,9 +76,6 @@ const sortComparatorTitle = (a, b) => (a.title || '').localeCompare(b.title);
 
 const GetListFrom = Symbol();
 
-export default
-@mixin(ActivityMixin)
-@exposeOrderBySymbols
 class Collection extends Base {
 
 	/**
@@ -460,3 +458,8 @@ class Collection extends Base {
 		return finalGrade ? finalGrade.getID() : void 0;
 	}
 }
+
+export default decorate(Collection, {with:[
+	mixin(ActivityMixin),
+	exposeOrderBySymbols,
+]});

--- a/src/models/assessment/assignment/DiscussionAssignment.js
+++ b/src/models/assessment/assignment/DiscussionAssignment.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {Service} from '../../../constants';
 import {model, COMMON_PREFIX} from '../../Registry';
 
 import Assignment from './Assignment';
 
-export default
-@model
 class DiscussionAssignment extends Assignment {
 	static MimeType = COMMON_PREFIX + 'assessment.discussionassignment'
 
@@ -22,3 +22,5 @@ class DiscussionAssignment extends Assignment {
 		return this.fetchLinkParsed('ResolveTopic', params);
 	}
 }
+
+export default decorate(DiscussionAssignment, {with:[model]});

--- a/src/models/assessment/assignment/MetadataAttemptItem.js
+++ b/src/models/assessment/assignment/MetadataAttemptItem.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import Base from '../../Base';
 import { model, COMMON_PREFIX } from '../../Registry';
 
-export default
-@model
 class MetadataAttemptItem extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.userscourseassignmentattemptmetadataitem';
 
@@ -23,3 +23,5 @@ class MetadataAttemptItem extends Base {
 		return this.fetchLinkParsed('HistoryItem');
 	}
 }
+
+export default decorate(MetadataAttemptItem, {with:[model]});

--- a/src/models/assessment/assignment/MetadataAttemptItemContainer.js
+++ b/src/models/assessment/assignment/MetadataAttemptItemContainer.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import Base from '../../Base';
 import { model, COMMON_PREFIX } from '../../Registry';
 
-export default
-@model
 class MetadataAttemptItemContainer extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.userscourseassignmentattemptmetadataitemcontainer'
 
@@ -14,3 +14,5 @@ class MetadataAttemptItemContainer extends Base {
 		return this.Items ? this.Items[this.Items.length - 1] : null;
 	}
 }
+
+export default decorate(MetadataAttemptItemContainer, {with:[model]});

--- a/src/models/assessment/assignment/SavePointItem.js
+++ b/src/models/assessment/assignment/SavePointItem.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class SavePointItem extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'assessment.savepointitem',
@@ -23,8 +23,10 @@ class SavePointItem extends Base {
 	isSyntheticSubmission () {
 		return false;
 	}
-	
+
 
 	isSubmitted () { return false; }
 
 }
+
+export default decorate(SavePointItem, {with:[model]});

--- a/src/models/assessment/assignment/TimedAssignment.js
+++ b/src/models/assessment/assignment/TimedAssignment.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {Service} from '../../../constants';
 import {model, COMMON_PREFIX} from '../../Registry';
 
@@ -5,8 +7,6 @@ import Assignment from './Assignment';
 
 const secondsToMilliseconds = s => s * 1000;
 
-export default
-@model
 class TimedAssignment extends Assignment {
 	static MimeType = COMMON_PREFIX + 'assessment.timedassignment'
 
@@ -76,3 +76,5 @@ class TimedAssignment extends Assignment {
 			(max - (now - start));
 	}
 }
+
+export default decorate(TimedAssignment, {with:[model]});

--- a/src/models/assessment/parts/File.js
+++ b/src/models/assessment/parts/File.js
@@ -1,12 +1,10 @@
 import path from 'path';
 
-import {FileType} from '@nti/lib-commons';
+import {decorate,FileType} from '@nti/lib-commons';
 
 import {model, COMMON_PREFIX} from '../../Registry';
 import Part from '../Part';
 
-export default
-@model
 class File extends Part {
 	static MimeType = COMMON_PREFIX + 'assessment.filepart'
 
@@ -49,3 +47,5 @@ class File extends Part {
 	}
 
 }
+
+export default decorate(File, {with:[model]});

--- a/src/models/assessment/parts/FillInTheBlank.js
+++ b/src/models/assessment/parts/FillInTheBlank.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Part from '../Part';
 
@@ -9,8 +11,6 @@ const keyName = /name=['"]([^'"]+)['"]/i;
 
 const ValueKeys = Symbol('value-keys');
 
-export default
-@model
 class FillInTheBlank extends Part {
 	static MimeType = [
 		COMMON_PREFIX + 'assessment.fillintheblank',
@@ -56,3 +56,5 @@ class FillInTheBlank extends Part {
 		return maybe;
 	}
 }
+
+export default decorate(FillInTheBlank, {with:[model]});

--- a/src/models/assessment/parts/FreeResponse.js
+++ b/src/models/assessment/parts/FreeResponse.js
@@ -1,8 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Part from '../Part';
 
-export default
-@model
 class FreeResponse extends Part {
 	static MimeType = COMMON_PREFIX + 'assessment.freeresponsepart'
 }
+
+export default decorate(FreeResponse, {with:[model]});

--- a/src/models/assessment/parts/Matching.js
+++ b/src/models/assessment/parts/Matching.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Part from '../Part';
 
-export default
-@model
 class Matching extends Part {
 	static MimeType = COMMON_PREFIX + 'assessment.matchingpart'
 
@@ -24,3 +24,5 @@ class Matching extends Part {
 		return maybe;
 	}
 }
+
+export default decorate(Matching, {with:[model]});

--- a/src/models/assessment/parts/Math.js
+++ b/src/models/assessment/parts/Math.js
@@ -1,8 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Part from '../Part';
 
-export default
-@model
 class Math extends Part {
 	static MimeType = COMMON_PREFIX + 'assessment.mathpart'
 }
+
+export default decorate(Math, {with:[model]});

--- a/src/models/assessment/parts/ModeledContent.js
+++ b/src/models/assessment/parts/ModeledContent.js
@@ -1,8 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Part from '../Part';
 
-export default
-@model
 class ModeledContent extends Part {
 	static MimeType = COMMON_PREFIX + 'assessment.modeledcontentpart'
 }
+
+export default decorate(ModeledContent, {with:[model]});

--- a/src/models/assessment/parts/MultipleChoice.js
+++ b/src/models/assessment/parts/MultipleChoice.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Part from '../Part';
 
-export default
-@model
 class MultipleChoice extends Part {
 	static MimeType = [
 		COMMON_PREFIX + 'assessment.multiplechoicepart',
@@ -16,3 +16,5 @@ class MultipleChoice extends Part {
 		'choices': { type: 'string[]', content: true },
 	}
 }
+
+export default decorate(MultipleChoice, {with:[model]});

--- a/src/models/assessment/parts/NumericMath.js
+++ b/src/models/assessment/parts/NumericMath.js
@@ -1,8 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Part from '../Part';
 
-export default
-@model
 class NumericMath extends Part {
 	static MimeType = COMMON_PREFIX + 'assessment.numericmathpart'
 }
+
+export default decorate(NumericMath, {with:[model]});

--- a/src/models/assessment/parts/Ordering.js
+++ b/src/models/assessment/parts/Ordering.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Part from '../Part';
 
-export default
-@model
 class Ordering extends Part {
 	static MimeType = COMMON_PREFIX + 'assessment.orderingpart'
 
@@ -18,3 +18,5 @@ class Ordering extends Part {
 		return {...(this.labels || []).map((_, i) => i)};
 	}
 }
+
+export default decorate(Ordering, {with:[model]});

--- a/src/models/assessment/parts/SymbolicMath.js
+++ b/src/models/assessment/parts/SymbolicMath.js
@@ -1,8 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Part from '../Part';
 
-export default
-@model
 class SymbolicMath extends Part {
 	static MimeType = COMMON_PREFIX + 'assessment.symbolicmathpart'
 }
+
+export default decorate(SymbolicMath, {with:[model]});

--- a/src/models/assessment/parts/non-gradable/FreeResponse.js
+++ b/src/models/assessment/parts/non-gradable/FreeResponse.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../../Registry';
 import FreeResponse from '../FreeResponse';
 
-export default
-@model
 class NonGradableFreeResponse extends FreeResponse {
 	static MimeType = COMMON_PREFIX + 'assessment.nongradablefreeresponsepart'
 	isNonGradable = true
 }
+
+export default decorate(NonGradableFreeResponse, {with:[model]});

--- a/src/models/assessment/parts/non-gradable/Matching.js
+++ b/src/models/assessment/parts/non-gradable/Matching.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../../Registry';
 import Matching from '../Matching';
 
-export default
-@model
 class NonGradableMatching extends Matching {
 	static MimeType = COMMON_PREFIX + 'assessment.nongradablematchingpart'
 	isNonGradable = true
 }
+
+export default decorate(NonGradableMatching, {with:[model]});

--- a/src/models/assessment/parts/non-gradable/ModeledContent.js
+++ b/src/models/assessment/parts/non-gradable/ModeledContent.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../../Registry';
 import ModeledContent from '../ModeledContent';
 
-export default
-@model
 class NonGradableModeledContent extends ModeledContent {
 	static MimeType = COMMON_PREFIX + 'assessment.nongradablemodeledcontentpart'
 	isNonGradable = true
 }
+
+export default decorate(NonGradableModeledContent, {with:[model]});

--- a/src/models/assessment/parts/non-gradable/MultipleChoice.js
+++ b/src/models/assessment/parts/non-gradable/MultipleChoice.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../../Registry';
 import MultipleChoice from '../MultipleChoice';
 
-export default
-@model
 class NonGradableMultipleChoice extends MultipleChoice {
 	static MimeType = [
 		COMMON_PREFIX + 'assessment.nongradablemultiplechoicepart',
@@ -11,3 +11,5 @@ class NonGradableMultipleChoice extends MultipleChoice {
 
 	isNonGradable = true
 }
+
+export default decorate(NonGradableMultipleChoice, {with:[model]});

--- a/src/models/assessment/parts/non-gradable/Ordering.js
+++ b/src/models/assessment/parts/non-gradable/Ordering.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../../Registry';
 import Ordering from '../Ordering';
 
-export default
-@model
 class NonGradableOrdering extends Ordering {
 	static MimeType = COMMON_PREFIX + 'assessment.nongradableorderingpart'
 	isNonGradable = true
 }
+
+export default decorate(NonGradableOrdering, {with:[model]});

--- a/src/models/assessment/survey/InquiryItem.js
+++ b/src/models/assessment/survey/InquiryItem.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
-class InqueryItem extends Base {
+class InquiryItem extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'assessment.inquiryitem',
 		COMMON_PREFIX + 'assessment.userscourseinquiryitem',
@@ -30,3 +30,5 @@ class InqueryItem extends Base {
 		return !!this.Submission;
 	}
 }
+
+export default decorate(InquiryItem, {with:[model]});

--- a/src/models/assessment/survey/InquiryItemResponse.js
+++ b/src/models/assessment/survey/InquiryItemResponse.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
-class InqueryItemResponse extends Base {
+class InquiryItemResponse extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.userscourseinquiryitemresponse'
 
 	static Fields = {
@@ -23,3 +23,5 @@ class InqueryItemResponse extends Base {
 		return !!this.Submission || this.Aggregated;
 	}
 }
+
+export default decorate(InquiryItemResponse, {with:[model]});

--- a/src/models/assessment/survey/Poll.js
+++ b/src/models/assessment/survey/Poll.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin/*, readonly*/} from '@nti/lib-decorators';
 
 import {
@@ -10,9 +11,6 @@ import Question from '../Question';
 
 import PollSubmission from './PollSubmission';
 
-export default
-@model
-@mixin({/*@readonly*/ isPoll: true})
 class Poll extends Question {
 	static MimeType = COMMON_PREFIX + 'napoll'
 
@@ -48,3 +46,8 @@ class Poll extends Question {
 		return this.fetchLinkParsed(ASSESSMENT_HISTORY_LINK);
 	}
 }
+
+export default decorate(Poll, {with: [
+	model,
+	mixin({/*@readonly*/ isPoll: true}),
+]});

--- a/src/models/assessment/survey/PollReference.js
+++ b/src/models/assessment/survey/PollReference.js
@@ -1,8 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class PollReference extends Base {
 	static MimeType = COMMON_PREFIX + 'pollref'
 }
+
+export default decorate(PollReference, {with:[model]});

--- a/src/models/assessment/survey/PollSubmission.js
+++ b/src/models/assessment/survey/PollSubmission.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import QuestionSubmission from '../QuestionSubmission';
 import {resolveSubmitTo} from '../utils';
 
-export default
-@model
 class PollSubmission extends QuestionSubmission {
 	static MimeType = COMMON_PREFIX + 'assessment.pollsubmission'
 	static COURSE_SUBMISSION_REL = 'CourseInquiries'
@@ -50,3 +50,5 @@ class PollSubmission extends QuestionSubmission {
 		return this.parts && this.parts.filter(answered).length > 0;
 	}
 }
+
+export default decorate(PollSubmission, {with:[model]});

--- a/src/models/assessment/survey/Survey.js
+++ b/src/models/assessment/survey/Survey.js
@@ -1,4 +1,4 @@
-import {wait} from '@nti/lib-commons';
+import {decorate, wait} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {
@@ -14,9 +14,6 @@ import SurveySubmission from './SurveySubmission';
 
 const AGGREGATED = Symbol(SURVEY_AGGREGATED_LINK);
 
-export default
-@model
-@mixin(Completable)
 class Survey extends QuestionSet {
 	static MimeType = COMMON_PREFIX + 'nasurvey'
 
@@ -59,3 +56,8 @@ class Survey extends QuestionSet {
 		return this.fetchLinkParsed(ASSESSMENT_HISTORY_LINK);
 	}
 }
+
+export default decorate(Survey, {with:[
+	model,
+	mixin(Completable),
+]});

--- a/src/models/assessment/survey/SurveyReference.js
+++ b/src/models/assessment/survey/SurveyReference.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import Completable from '../../../mixins/Completable';
@@ -5,9 +6,6 @@ import {ASSESSMENT_HISTORY_LINK} from '../../../constants';
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
-@mixin(Completable)
 class SurveyReference extends Base {
 	static MimeType = COMMON_PREFIX + 'surveyref'
 
@@ -33,3 +31,8 @@ class SurveyReference extends Base {
 		return this['Target-NTIID'];
 	}
 }
+
+export default decorate(SurveyReference, {with: [
+	model,
+	mixin(Completable),
+]});

--- a/src/models/assessment/survey/SurveySubmission.js
+++ b/src/models/assessment/survey/SurveySubmission.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import QuestionSetSubmission from '../QuestionSetSubmission';
 import {resolveSubmitTo} from '../utils';
 
-export default
-@model
 class SurveySubmission extends QuestionSetSubmission {
 	static MimeType = COMMON_PREFIX + 'assessment.surveysubmission'
 	static COURSE_SUBMISSION_REL = 'CourseInquiries'
@@ -42,3 +42,5 @@ class SurveySubmission extends QuestionSetSubmission {
 		return this.surveyId || this.NTIID;
 	}
 }
+
+export default decorate(SurveySubmission, {with:[model]});

--- a/src/models/assessment/survey/aggregated/Poll.js
+++ b/src/models/assessment/survey/aggregated/Poll.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../../Registry';
 import Base from '../../../Base';
 
-export default
-@model
 class AggregatedPoll extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.aggregatedpoll'
 
@@ -18,3 +18,5 @@ class AggregatedPoll extends Base {
 		return this.pollId;
 	}
 }
+
+export default decorate(AggregatedPoll, {with:[model]});

--- a/src/models/assessment/survey/aggregated/Survey.js
+++ b/src/models/assessment/survey/aggregated/Survey.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../../Registry';
 import Base from '../../../Base';
 
-export default
-@model
 class AggregatedSurveyResults extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.aggregatedsurvey'
 
@@ -23,3 +23,5 @@ class AggregatedSurveyResults extends Base {
 			found || (q.getID() === id && q), null);
 	}
 }
+
+export default decorate(AggregatedSurveyResults, {with:[model]});

--- a/src/models/assessment/survey/aggregated/parts/FreeResponse.js
+++ b/src/models/assessment/survey/aggregated/parts/FreeResponse.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 // import {Parser as parse} from '../../../../../constants';
 import {model, COMMON_PREFIX} from '../../../../Registry';
 
 import Base from './Part';
 
-export default
-@model
 class AggregatedFreeResponsePart extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.aggregatedfreeresponsepart'
 
@@ -13,3 +13,5 @@ class AggregatedFreeResponsePart extends Base {
 		return this.Results;
 	}
 }
+
+export default decorate(AggregatedFreeResponsePart, {with:[model]});

--- a/src/models/assessment/survey/aggregated/parts/Matching.js
+++ b/src/models/assessment/survey/aggregated/parts/Matching.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 // import {Parser as parse} from '../../../../../constants';
 import {model, COMMON_PREFIX} from '../../../../Registry';
 
 import Base from './Ordering';
 
-export default
-@model
 class AggregatedMatchingPart extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.aggregatedmatchingpart'
 
@@ -30,3 +30,5 @@ class AggregatedMatchingPart extends Base {
 		return pivotData;
 	}
 }
+
+export default decorate(AggregatedMatchingPart, {with:[model]});

--- a/src/models/assessment/survey/aggregated/parts/ModeledContent.js
+++ b/src/models/assessment/survey/aggregated/parts/ModeledContent.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 // import {Parser as parse} from '../../../../../constants';
 import {model, COMMON_PREFIX} from '../../../../Registry';
 
 import Base from './Part';
 
-export default
-@model
 class AggregatedModeledContentPart extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.aggregatedmodeledcontentpart'
 
@@ -12,3 +12,5 @@ class AggregatedModeledContentPart extends Base {
 		return this.Results;
 	}
 }
+
+export default decorate(AggregatedModeledContentPart, {with:[model]});

--- a/src/models/assessment/survey/aggregated/parts/MultipleChoice.js
+++ b/src/models/assessment/survey/aggregated/parts/MultipleChoice.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 // import {Parser as parse} from '../../../../../constants';
 import {model, COMMON_PREFIX} from '../../../../Registry';
 
 import Base from './Part';
 
-export default
-@model
 class AggregatedMultipleChoicePart extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.aggregatedmultiplechoicepart'
 
@@ -29,3 +29,5 @@ class AggregatedMultipleChoicePart extends Base {
 		}));
 	}
 }
+
+export default decorate(AggregatedMultipleChoicePart, {with:[model]});

--- a/src/models/assessment/survey/aggregated/parts/MultipleChoiceMultipleAnswer.js
+++ b/src/models/assessment/survey/aggregated/parts/MultipleChoiceMultipleAnswer.js
@@ -1,10 +1,12 @@
+import {decorate} from '@nti/lib-commons';
+
 // import {Parser as parse} from '../../../../../constants';
 import {model, COMMON_PREFIX} from '../../../../Registry';
 
 import Base from './MultipleChoice';
 
-export default
-@model
 class AggregatedMultipleChoiceMultipleAnswerPart extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.aggregatedmultiplechoicemultipleanswerpart'
 }
+
+export default decorate(AggregatedMultipleChoiceMultipleAnswerPart, {with:[model]});

--- a/src/models/assessment/survey/aggregated/parts/Ordering.js
+++ b/src/models/assessment/survey/aggregated/parts/Ordering.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 // import {Parser as parse} from '../../../../../constants';
 import {model, COMMON_PREFIX} from '../../../../Registry';
 
 import Base from './Part';
 
-export default
-@model
 class AggregatedOrderingPart extends Base {
 	static MimeType = COMMON_PREFIX + 'assessment.aggregatedorderingpart'
 
@@ -60,3 +60,5 @@ class AggregatedOrderingPart extends Base {
 		});
 	}
 }
+
+export default decorate(AggregatedOrderingPart, {with:[model]});

--- a/src/models/assessment/survey/aggregated/parts/Part.js
+++ b/src/models/assessment/survey/aggregated/parts/Part.js
@@ -1,9 +1,8 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin/*, readonly*/} from '@nti/lib-decorators';
 
 import Base from '../../../../Base';
 
-export default
-@mixin({/*@readonly*/ isAggregated: true})
 class Part extends Base {
 
 	static Fields = {
@@ -17,3 +16,7 @@ class Part extends Base {
 		throw new Error('Not Implemented');
 	}
 }
+
+export default decorate(Part, {with: [
+	mixin({/*@readonly*/ isAggregated: true}),
+]});

--- a/src/models/calendar/CalendarEventRef.js
+++ b/src/models/calendar/CalendarEventRef.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CalendarEventRef extends Base {
 	static MimeType = `${COMMON_PREFIX}nticalendareventref`
 
@@ -20,3 +20,5 @@ class CalendarEventRef extends Base {
 		return this.target === id;
 	}
 }
+
+export default decorate(CalendarEventRef, {with:[model]});

--- a/src/models/calendar/CourseCalendar.js
+++ b/src/models/calendar/CourseCalendar.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CourseCalendar extends Base {
 	static MimeType = `${COMMON_PREFIX}courseware.coursecalendar`
 
@@ -12,3 +12,5 @@ class CourseCalendar extends Base {
 		'CatalogEntry': { type: 'model'  }
 	}
 }
+
+export default decorate(CourseCalendar, {with:[model]});

--- a/src/models/calendar/UserCalendar.js
+++ b/src/models/calendar/UserCalendar.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class UserCalendar extends Base {
 	static MimeType = `${COMMON_PREFIX}calendar.usercalendar`
 
@@ -10,3 +10,5 @@ class UserCalendar extends Base {
 		...Base.Fields,
 	}
 }
+
+export default decorate(UserCalendar, {with:[model]});

--- a/src/models/calendar/events/AssignmentCalendarEvent.js
+++ b/src/models/calendar/events/AssignmentCalendarEvent.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import { model, COMMON_PREFIX } from '../../Registry';
 
 import BaseEvent from './BaseEvent';
 
-export default
-@model
 class AssignmentCalendarEvent extends BaseEvent {
 	static MimeType = `${COMMON_PREFIX}assessment.assignmentcalendarevent`
 
@@ -22,3 +22,5 @@ class AssignmentCalendarEvent extends BaseEvent {
 
 	getUniqueIdentifier = () => this.AssignmentNTIID + this.CatalogEntryNTIID;
 }
+
+export default decorate(AssignmentCalendarEvent, {with:[model]});

--- a/src/models/calendar/events/BaseEvent.js
+++ b/src/models/calendar/events/BaseEvent.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import { model } from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class BaseEvent extends Base {
 	static MimeType = '__base-event__';
 
@@ -20,3 +20,5 @@ class BaseEvent extends Base {
 
 	getUniqueIdentifier = () => this.getID();
 }
+
+export default decorate(BaseEvent, {with:[model]});

--- a/src/models/calendar/events/CourseCalendarEvent.js
+++ b/src/models/calendar/events/CourseCalendarEvent.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 
 import BaseEvent from './BaseEvent';
 
-export default
-@model
 class CourseCalendarEvent extends BaseEvent {
 	static MimeType = `${COMMON_PREFIX}courseware.coursecalendarevent`
 
@@ -11,3 +11,5 @@ class CourseCalendarEvent extends BaseEvent {
 		...BaseEvent.Fields,
 	}
 }
+
+export default decorate(CourseCalendarEvent, {with:[model]});

--- a/src/models/calendar/events/WebinarCalendarEvent.js
+++ b/src/models/calendar/events/WebinarCalendarEvent.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import { model, COMMON_PREFIX } from '../../Registry';
 
 import BaseEvent from './BaseEvent';
 
-export default
-@model
 class WebinarCalendarEvent extends BaseEvent {
 	static MimeType = `${COMMON_PREFIX}webinar.webinarcalendarevent`
 
@@ -15,3 +15,5 @@ class WebinarCalendarEvent extends BaseEvent {
 		return this.href;
 	}
 }
+
+export default decorate(WebinarCalendarEvent, {with:[model]});

--- a/src/models/catalog/Families.js
+++ b/src/models/catalog/Families.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CatalogFamilies extends Base {
 	static MimeType = COMMON_PREFIX + 'catalogfamilies'
 
@@ -49,3 +49,5 @@ class CatalogFamilies extends Base {
 		return this.Items.map(family => family.getFamilyID());
 	}
 }
+
+export default decorate(CatalogFamilies, {with:[model]});

--- a/src/models/catalog/Family.js
+++ b/src/models/catalog/Family.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CatalogFamily extends Base {
 	static MimeType = COMMON_PREFIX + 'catalogfamily'
 
@@ -27,3 +27,5 @@ class CatalogFamily extends Base {
 		};
 	}
 }
+
+export default decorate(CatalogFamily, {with:[model]});

--- a/src/models/chat/MessageInfo.js
+++ b/src/models/chat/MessageInfo.js
@@ -1,4 +1,4 @@
-import {pluck} from '@nti/lib-commons';
+import {decorate, pluck} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {NO_LINK} from '../../constants';
@@ -6,9 +6,6 @@ import Threadable from '../../mixins/Threadable';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(Threadable)
 class MessageInfo extends Base {
 	static MimeType = COMMON_PREFIX + 'messageinfo'
 
@@ -40,3 +37,8 @@ class MessageInfo extends Base {
 			.then(() => this.onChange('flag'));
 	}
 }
+
+export default decorate(MessageInfo, {with: [
+	model,
+	mixin(Threadable),
+]});

--- a/src/models/chat/RoomInfo.js
+++ b/src/models/chat/RoomInfo.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
 
-export default
-@model
 class RoomInfo extends Base {
 	static MimeType = [
 		COMMON_PREFIX + '_meeting',
@@ -20,3 +20,5 @@ class RoomInfo extends Base {
 		'Occupants':    { type: 'string[]', name: 'occupants'    },
 	}
 }
+
+export default decorate(RoomInfo, {with:[model]});

--- a/src/models/chat/Transcript.js
+++ b/src/models/chat/Transcript.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {thread} from '../../utils/UserDataThreader';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
 
-export default
-@model
 class Transcript extends Base {
 	static MimeType = COMMON_PREFIX + 'transcript'
 
@@ -45,3 +45,5 @@ class Transcript extends Base {
 		return contributors.filter( x => x !== originator);
 	}
 }
+
+export default decorate(Transcript, {with:[model]});

--- a/src/models/chat/TranscriptSummary.js
+++ b/src/models/chat/TranscriptSummary.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Transcript from './Transcript';
 
-export default
-@model
 class TranscriptSummary extends Transcript {
 	static MimeType = COMMON_PREFIX + 'transcriptsummary'
 
@@ -11,3 +11,5 @@ class TranscriptSummary extends Transcript {
 		return this.fetchLinkParsed('transcript');
 	}
 }
+
+export default decorate(TranscriptSummary, {with:[model]});

--- a/src/models/completion/AssignmentCompletionMetadata.js
+++ b/src/models/completion/AssignmentCompletionMetadata.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class AssignmentCompletionMetadata extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'assignmentcompletionmetadata',
@@ -27,3 +27,5 @@ class AssignmentCompletionMetadata extends Base {
 
 	getCompletionDate () { } //implemented by CompletionDate date field.
 }
+
+export default decorate(AssignmentCompletionMetadata, {with:[model]});

--- a/src/models/completion/CompletionMetadata.js
+++ b/src/models/completion/CompletionMetadata.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CompletionMetadata extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'completion.completionmetadata',
@@ -17,3 +17,5 @@ class CompletionMetadata extends Base {
 	}
 
 }
+
+export default decorate(CompletionMetadata, {with:[model]});

--- a/src/models/completion/Policy.js
+++ b/src/models/completion/Policy.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CompletionPolicy extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'completion.aggregatecompletionpolicy'
@@ -14,3 +14,5 @@ class CompletionPolicy extends Base {
 		'offers_completion_certificate': { type: 'boolean', name: 'offersCompletionCertificate' }
 	}
 }
+
+export default decorate(CompletionPolicy, {with:[model]});

--- a/src/models/completion/Progress.js
+++ b/src/models/completion/Progress.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
@@ -5,8 +7,6 @@ const HasCompleted = Symbol('Has Completed Field');
 const HasProgress = Symbol('Has Progress Field');
 const ResourceID = Symbol('Resource ID Field');
 
-export default
-@model
 class Progress extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'progress',
@@ -47,3 +47,5 @@ class Progress extends Base {
 		return this[ResourceID] || super.getID();
 	}
 }
+
+export default decorate(Progress, {with:[model]});

--- a/src/models/completion/ScormCompletionMetadata.js
+++ b/src/models/completion/ScormCompletionMetadata.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class SCORMCompletionMetadata extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'scormcompletionmetadata',
@@ -19,3 +19,5 @@ class SCORMCompletionMetadata extends Base {
 
 	getCompletionDate () { } //implemented by CompletionDate date field.
 }
+
+export default decorate(SCORMCompletionMetadata, {with:[model]});

--- a/src/models/constraints/LessonPublicationConstraints.js
+++ b/src/models/constraints/LessonPublicationConstraints.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Constraints from './Constraints';
 
-export default
-@model
 class LessonPublicationConstraints extends Constraints {
 	static MimeType = COMMON_PREFIX + 'lesson.publicationconstraints'
 }
+
+export default decorate(LessonPublicationConstraints, {with:[model]});

--- a/src/models/constraints/constraint-types/AssignmentCompletionConstraint.js
+++ b/src/models/constraints/constraint-types/AssignmentCompletionConstraint.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class AssignmentCompletionConstraint extends Base {
 	static MimeType = COMMON_PREFIX + 'lesson.assignmentcompletionconstraint'
 
@@ -18,3 +18,5 @@ class AssignmentCompletionConstraint extends Base {
 		return assignments && assignments.some(assignment => assignment === id);
 	}
 }
+
+export default decorate(AssignmentCompletionConstraint, {with:[model]});

--- a/src/models/content/Bundle.js
+++ b/src/models/content/Bundle.js
@@ -1,4 +1,4 @@
-import {URL, forward} from '@nti/lib-commons';
+import {decorate,URL, forward} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 import Logger from '@nti/util-logger';
 
@@ -19,9 +19,6 @@ const BundleCommunityCache = Symbol('Bundle Community Cache');
 
 const names = (x, y, v) => Array.isArray(v) ? v.join(', ') : null;
 
-export default
-@model
-@mixin(forward(['every','filter','forEach','map', 'reduce'], 'ContentPackages'), Publishable)
 class Bundle extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'contentpackagebundle',
@@ -209,3 +206,8 @@ async function resolveDiscussions (bundle) {
 		//swallow
 	}
 }
+
+export default decorate(Bundle, {with:[
+	model,
+	mixin(forward(['every','filter','forEach','map', 'reduce'], 'ContentPackages'), Publishable),
+]});

--- a/src/models/content/ContentPackageRenderJob.js
+++ b/src/models/content/ContentPackageRenderJob.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {Service} from '../../constants';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
@@ -22,8 +24,6 @@ function getIntervalTimeout (interval) {
 	}
 }
 
-export default
-@model
 class ContentPackageRenderJob extends Base {
 	static MimeType = COMMON_PREFIX + 'content.packagerenderjob'
 
@@ -122,3 +122,5 @@ class ContentPackageRenderJob extends Base {
 		}
 	}
 }
+
+export default decorate(ContentPackageRenderJob, {with:[model]});

--- a/src/models/content/File.js
+++ b/src/models/content/File.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import FileSystemEntity from './FileSystemEntity';
@@ -7,8 +9,6 @@ import FileSystemEntity from './FileSystemEntity';
 //	associate    - ?
 //	external     - ?
 
-export default
-@model
 class File extends FileSystemEntity {
 	static MimeType = [
 		COMMON_PREFIX + 'contentfile',
@@ -44,3 +44,5 @@ class File extends FileSystemEntity {
 		return this['download_url'];
 	}
 }
+
+export default decorate(File, {with:[model]});

--- a/src/models/content/Folder.js
+++ b/src/models/content/Folder.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {Service} from '../../constants';
 import {model, COMMON_PREFIX} from '../Registry';
 
 import FileSystemEntity, {validateSortObject} from './FileSystemEntity';
 
-export default
-@model
 class Folder extends FileSystemEntity {
 	static MimeType = [
 		COMMON_PREFIX + 'contentfolder',
@@ -51,3 +51,5 @@ class Folder extends FileSystemEntity {
 	}
 
 }
+
+export default decorate(Folder, {with:[model]});

--- a/src/models/content/ImageMetadata.js
+++ b/src/models/content/ImageMetadata.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class ImageMetadata extends Base {
 	static MimeType = COMMON_PREFIX + 'metadata.imagemetadata'
 	static Fields = {
@@ -15,3 +15,6 @@ class ImageMetadata extends Base {
 	// known links:
 	// - safeimage
 }
+
+
+export default decorate(ImageMetadata, {with:[model]});

--- a/src/models/content/LTIExternalToolAsset.js
+++ b/src/models/content/LTIExternalToolAsset.js
@@ -1,10 +1,9 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import { model, COMMON_PREFIX } from '../Registry';
 import Completable from '../../mixins/Completable';
 import Base from '../Base';
-
-// @mixin(Completable)
 
 /*
 	description: data.description,
@@ -13,10 +12,6 @@ import Base from '../Base';
 	ConfiguredTool: data.ConfiguredTool,
 	NTIID: data.ntiid
 */
-
-export default
-@model
-@mixin(Completable)
 class LTIExternalToolAsset extends Base {
 	static MimeType = COMMON_PREFIX + 'ltiexternaltoolasset'
 
@@ -47,3 +42,8 @@ class LTIExternalToolAsset extends Base {
 		return p && p.icon;
 	}
 }
+
+export default decorate(LTIExternalToolAsset, {with:[
+	model,
+	mixin(Completable),
+]});

--- a/src/models/content/Metadata.js
+++ b/src/models/content/Metadata.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class Metadata extends Base {
 	static MimeType = COMMON_PREFIX + 'metadata.contentmetadata'
 
@@ -17,3 +17,5 @@ class Metadata extends Base {
 		'title':           { type: 'string'  },
 	}
 }
+
+export default decorate(Metadata, {with:[model]});

--- a/src/models/content/Package.js
+++ b/src/models/content/Package.js
@@ -1,5 +1,5 @@
+import {decorate,URL} from '@nti/lib-commons';
 import Logger from '@nti/util-logger';
-import {URL} from '@nti/lib-commons';
 
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
@@ -18,8 +18,6 @@ const VideoIndexReqest = Symbol('VideoIndexReqest');
 const getAssociationCount = (x) => x.LessonContainerCount;
 const names = (x, y, v) => Array.isArray(v) ? v.join(', ') : null;
 
-export default
-@model
 class Package extends Base {
 	static MimeType = COMMON_PREFIX + 'contentpackage'
 
@@ -173,3 +171,5 @@ class Package extends Base {
 		}
 	}
 }
+
+export default decorate(Package, {with:[model]});

--- a/src/models/content/PageInfo.js
+++ b/src/models/content/PageInfo.js
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import {Markup, URL} from '@nti/lib-commons';
+import {decorate,Markup, URL} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import UserDataStore from '../../stores/UserData';
@@ -21,9 +21,6 @@ const NOT_FOUND = {statusCode: 404, message: 'Not Found'};
 const UserData = Symbol('UserData');
 const ContentPackageMimeTypes = 'application/vnd.nextthought.renderablecontentpackage';
 
-export default
-@model
-@mixin(Pages)
 class PageInfo extends Base {
 	static MimeType = COMMON_PREFIX + 'pageinfo'
 
@@ -214,3 +211,8 @@ function setupAssessmentItems (items, pageInfo) {
 			found || set.containsId(o.getID()), null)
 	);
 }
+
+export default decorate(PageInfo, {with:[
+	model,
+	mixin(Pages),
+]});

--- a/src/models/content/RelatedWorkReference.js
+++ b/src/models/content/RelatedWorkReference.js
@@ -1,6 +1,7 @@
 import {parse as parseUrl} from 'url';
 import {extname} from 'path';
 
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 import mime from 'mime-types';
 import {isNTIID} from '@nti/lib-ntiids';
@@ -42,9 +43,6 @@ External Links:
 const CONTENT_TYPE = 'application/vnd.nextthought.content';
 const EXTERNAL_TYPE = 'application/vnd.nextthought.externallink';
 
-export default
-@model
-@mixin(Completable, ContentTreeMixin, Pages)
 class RelatedWorkReference extends Base {
 	static MimeType = COMMON_PREFIX + 'relatedworkref'
 
@@ -191,3 +189,8 @@ class RelatedWorkReference extends Base {
 		}
 	}
 }
+
+export default decorate(RelatedWorkReference, {with:[
+	model,
+	mixin(Completable, ContentTreeMixin, Pages),
+]});

--- a/src/models/content/RelatedWorkReferencePointer.js
+++ b/src/models/content/RelatedWorkReferencePointer.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
@@ -15,8 +17,6 @@ href: "/dataserver2/Objects/tag%3Anextthought.com%2C2011-10%3Aglobal.admin.alpha
 target :"tag:nextthought.com,2011-10:NTI-NTIRelatedWorkRef-global_admin_alpha1_4743953516163133541_b62c3bd2"
 */
 
-export default
-@model
 class RelatedWorkReferencePointer extends Base {
 	static MimeType = COMMON_PREFIX + 'relatedworkrefpointer'
 
@@ -26,3 +26,5 @@ class RelatedWorkReferencePointer extends Base {
 		'target':     { type: 'string'   },
 	}
 }
+
+export default decorate(RelatedWorkReferencePointer, {with:[model]});

--- a/src/models/content/RenderablePackage.js
+++ b/src/models/content/RenderablePackage.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {ntiidEquals} from '@nti/lib-ntiids';
 
 import {RepresentsSameObject} from '../../constants';
@@ -7,8 +8,6 @@ import Package from './Package';
 
 const RST_TYPE = 'text/x-rst';
 
-export default
-@model
 class RenderablePackage extends Package {
 	static MimeType = COMMON_PREFIX + 'renderablecontentpackage'
 
@@ -76,3 +75,5 @@ class RenderablePackage extends Package {
 			.then(() => this.onChange());
 	}
 }
+
+export default decorate(RenderablePackage, {with:[model]});

--- a/src/models/content/Root.js
+++ b/src/models/content/Root.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Folder from './Folder';
 
-export default
-@model
 class Root extends Folder {
 	static MimeType = [
 		COMMON_PREFIX + 'contentrootfolder',
@@ -13,3 +13,5 @@ class Root extends Folder {
 
 	isRoot = true
 }
+
+export default decorate(Root, {with:[model]});

--- a/src/models/content/SearchFragment.js
+++ b/src/models/content/SearchFragment.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-class Metadata extends Base {
+class SearchFragment extends Base {
 	static MimeType = COMMON_PREFIX + 'search.searchfragment'
 
 	static Fields = {
@@ -11,3 +11,5 @@ class Metadata extends Base {
 		'Field':   { type: 'string'   },
 	}
 }
+
+export default decorate(SearchFragment, {with:[model]});

--- a/src/models/content/SearchHit.js
+++ b/src/models/content/SearchHit.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class ContentUnitSearchHit extends Base {
 	static MimeType = COMMON_PREFIX + 'search.contentunitsearchhit'
 
@@ -18,3 +18,5 @@ class ContentUnitSearchHit extends Base {
 
 	isContentUnitSearchHit = true
 }
+
+export default decorate(ContentUnitSearchHit, {with:[model]});

--- a/src/models/content/SharingPagePreference.js
+++ b/src/models/content/SharingPagePreference.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {Service} from '../../constants';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
 
-export default
-@model
 class SharingPagePreference extends Base {
 	static MimeType = COMMON_PREFIX + 'sharingpagepreference'
 
@@ -33,3 +33,5 @@ class SharingPagePreference extends Base {
 		return this.addToPending(...resolving).waitForPending();
 	}
 }
+
+export default decorate(SharingPagePreference, {with:[model]});

--- a/src/models/content/UserBundleRecord.js
+++ b/src/models/content/UserBundleRecord.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class UserBundleRecord extends Base {
 	static MimeType = COMMON_PREFIX + 'userbundlerecord'
 
@@ -15,3 +15,5 @@ class UserBundleRecord extends Base {
 	}
 
 }
+
+export default decorate(UserBundleRecord, {with:[model]});

--- a/src/models/courses/AdministrativeRole.js
+++ b/src/models/courses/AdministrativeRole.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {model, COMMON_PREFIX} from '../Registry';
@@ -5,9 +6,6 @@ import {model, COMMON_PREFIX} from '../Registry';
 import AdministrativeIdentity from './mixins/AdministrativeIdentity';
 import Enrollment from './Enrollment';
 
-export default
-@model
-@mixin(AdministrativeIdentity)
 class InstanceAdministrativeRole extends Enrollment {
 	static MimeType = COMMON_PREFIX + 'courseware.courseinstanceadministrativerole'
 
@@ -88,3 +86,8 @@ function buildSuggestionsFrom (scopes, sectionName = 'My Course') {
 
 	return items;
 }
+
+export default decorate(InstanceAdministrativeRole, {with:[
+	model,
+	mixin(AdministrativeIdentity),
+]});

--- a/src/models/courses/CatalogEntry.js
+++ b/src/models/courses/CatalogEntry.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
@@ -7,8 +9,6 @@ import CatalogEntryFactory from './CatalogEntryFactory';
 const EnrollmentOptions = Symbol('EnrollmentOptions');
 
 
-export default
-@model
 class CourseCatalogEntry extends Base {
 	static MimeType = COMMON_PREFIX + 'courses.catalogentry'
 
@@ -115,3 +115,5 @@ class CourseCatalogEntry extends Base {
 		return CatalogFamilies.hasIntersectionWith(catalogEntry.CatalogFamilies);
 	}
 }
+
+export default decorate(CourseCatalogEntry, {with:[model]});

--- a/src/models/courses/CatalogInstructorLegacyInfo.js
+++ b/src/models/courses/CatalogInstructorLegacyInfo.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CatalogInstructorLegacyInfo extends Base {
 	static MimeType = COMMON_PREFIX + 'courses.coursecataloginstructorlegacyinfo'
 
@@ -16,3 +16,5 @@ class CatalogInstructorLegacyInfo extends Base {
 		'username':     { type: 'string' },
 	}
 }
+
+export default decorate(CatalogInstructorLegacyInfo, {with:[model]});

--- a/src/models/courses/CatalogLegacyEntry.js
+++ b/src/models/courses/CatalogLegacyEntry.js
@@ -1,11 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {encodeIdFrom} from '../../utils/href-ntiids';
 import {model, COMMON_PREFIX} from '../Registry';
 
 import CatalogEntry from './CatalogEntry';
 
 
-export default
-@model
 class CourseCatalogLegacyEntry extends CatalogEntry {
 	static MimeType = [
 		COMMON_PREFIX + 'courses.coursecataloglegacyentry', //Really?! Two packages?! :P
@@ -17,3 +17,5 @@ class CourseCatalogLegacyEntry extends CatalogEntry {
 		return encodeIdFrom(this.href);
 	}
 }
+
+export default decorate(CourseCatalogLegacyEntry, {with:[model]});

--- a/src/models/courses/CompletableItemDefaultRequiredPolicy.js
+++ b/src/models/courses/CompletableItemDefaultRequiredPolicy.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CompletableItemDefaultRequiredPolicy extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'completion.defaultrequiredpolicy',
@@ -13,3 +13,5 @@ class CompletableItemDefaultRequiredPolicy extends Base {
 		'mime_types': { type: 'string[]', name: 'mimeTypes' }
 	}
 }
+
+export default decorate(CompletableItemDefaultRequiredPolicy, {with:[model]});

--- a/src/models/courses/CompletedItem.js
+++ b/src/models/courses/CompletedItem.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 import CompletionMetadata from '../completion/CompletionMetadata';
 
-export default
-@model
 class CompletedItem extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'completion.completeditem',
@@ -18,3 +18,5 @@ class CompletedItem extends Base {
 
 	getCompletedDate () { } //implemented by CompletedDate date field.
 }
+
+export default decorate(CompletedItem, {with:[model]});

--- a/src/models/courses/CourseDiscussion.js
+++ b/src/models/courses/CourseDiscussion.js
@@ -1,11 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
 //TODO: does this need to live somewhere else
 const DEFAULT_ICON = '/app/resources/images/elements/discussion-icon.png';
 
-export default
-@model
 class CourseDiscussion extends Base {
 	static MimeType = COMMON_PREFIX + 'courses.discussion'
 
@@ -19,3 +19,5 @@ class CourseDiscussion extends Base {
 		return this.icon || DEFAULT_ICON;
 	}
 }
+
+export default decorate(CourseDiscussion, {with:[model]});

--- a/src/models/courses/CourseProgress.js
+++ b/src/models/courses/CourseProgress.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CourseProgress extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'completion.completioncontextprogress',
@@ -24,3 +24,5 @@ class CourseProgress extends Base {
 
 	getCompletedDate () {} //implemented by CompletedDate date field.
 }
+
+export default decorate(CourseProgress, {with:[model]});

--- a/src/models/courses/DiscussionReference.js
+++ b/src/models/courses/DiscussionReference.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {parseNTIID, isNTIID} from '@nti/lib-ntiids';
 
 import {model, COMMON_PREFIX} from '../Registry';
@@ -15,8 +16,6 @@ const RESOLVED_TARGET_NTIID = Symbol('Resolved Target NTIID');
 "title": "1.1 Warmer: Elias Hill"
 }
 */
-export default
-@model
 class DiscussionReference extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'discussion',
@@ -63,6 +62,9 @@ class DiscussionReference extends Base {
 		}
 	}
 }
+
+export default decorate(DiscussionReference, {with:[model]});
+
 
 function hasValidTargetNTIID (ref) {
 	return ref['Target-NTIID'] && isNTIID(ref['Target-NTIID']);

--- a/src/models/courses/Enrollment.js
+++ b/src/models/courses/Enrollment.js
@@ -1,4 +1,4 @@
-import {forward} from '@nti/lib-commons';
+import {decorate,forward} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {
@@ -13,17 +13,6 @@ import EnrollmentIdentity from './mixins/EnrollmentIdentity';
 const emptyFunction = () => {};
 const EMPTY_CATALOG_ENTRY = {getAuthorLine: emptyFunction};
 
-export default
-@model
-@mixin(
-	CourseIdentity,
-	EnrollmentIdentity,
-	forward([
-		'getEndDate',
-		'getStartDate'
-	//From:
-	], 'CatalogEntry')
-)
 class Enrollment extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'courses.courseenrollment',
@@ -121,3 +110,16 @@ class Enrollment extends Base {
 		this.CourseInstance = instance;
 	}
 }
+
+export default decorate(Enrollment, {with:[
+	model,
+	mixin(
+		CourseIdentity,
+		EnrollmentIdentity,
+		forward([
+			'getEndDate',
+			'getStartDate'
+		//From:
+		], 'CatalogEntry')
+	),
+]});

--- a/src/models/courses/EnrollmentOption.js
+++ b/src/models/courses/EnrollmentOption.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class EnrollmentOption extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'courseware.enrollmentoption',
@@ -17,3 +17,5 @@ class EnrollmentOption extends Base {
 	}
 
 }
+
+export default decorate(EnrollmentOption, {with:[model]});

--- a/src/models/courses/EnrollmentOption5Minute.js
+++ b/src/models/courses/EnrollmentOption5Minute.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import EnrollmentOption from './EnrollmentOption';
 
-export default
-@model
 class EnrollmentOption5Minute extends EnrollmentOption {
 	static MimeType = COMMON_PREFIX + 'courseware.fiveminuteenrollmentoption'
 
@@ -30,3 +30,5 @@ class EnrollmentOption5Minute extends EnrollmentOption {
 	getEnrollCutOffDate () {} //implemented by the date Field type
 	getRefundCutOffDate () {} //implemented by the date Field type
 }
+
+export default decorate(EnrollmentOption5Minute, {with:[model]});

--- a/src/models/courses/EnrollmentOptionContainer.js
+++ b/src/models/courses/EnrollmentOptionContainer.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class EnrollmentOptionContainer extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'courseware.enrollmentoptioncontainer',
@@ -15,3 +15,5 @@ class EnrollmentOptionContainer extends Base {
 		'ItemCount':                  { type: 'number'  }
 	}
 }
+
+export default decorate(EnrollmentOptionContainer, {with:[model]});

--- a/src/models/courses/EnrollmentOptionExternal.js
+++ b/src/models/courses/EnrollmentOptionExternal.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import EnrollmentOption from './EnrollmentOption';
 
-export default
-@model
 class EnrollmentOptionExternal extends EnrollmentOption {
 	static MimeType = [
 		COMMON_PREFIX + 'courseware.externalenrollmentoption',
@@ -15,3 +15,5 @@ class EnrollmentOptionExternal extends EnrollmentOption {
 		'enrollment_url':  { type: 'string', name: 'enrollmentURL' }
 	}
 }
+
+export default decorate(EnrollmentOptionExternal, {with:[model]});

--- a/src/models/courses/EnrollmentOptionOZone.js
+++ b/src/models/courses/EnrollmentOptionOZone.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import EnrollmentOption from './EnrollmentOption';
 
-export default
-@model
 class EnrollmentOptionOZone extends EnrollmentOption {
 	static MimeType = COMMON_PREFIX + 'courseware.ozoneenrollmentoption'
 }
+
+export default decorate(EnrollmentOptionOZone, {with:[model]});

--- a/src/models/courses/EnrollmentOptionPurchase.js
+++ b/src/models/courses/EnrollmentOptionPurchase.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
@@ -17,8 +19,6 @@ class Collection extends Base {
 }
 
 
-export default
-@model
 class EnrollmentOptionStore extends EnrollmentOption {
 	static MimeType = COMMON_PREFIX + 'courseware.storeenrollmentoption'
 
@@ -56,3 +56,5 @@ class EnrollmentOptionStore extends EnrollmentOption {
 		return null;
 	}
 }
+
+export default decorate(EnrollmentOptionStore, {with:[model]});

--- a/src/models/courses/EnrollmentOptions.js
+++ b/src/models/courses/EnrollmentOptions.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class EnrollmentOptions extends Base {
 	static MimeType = COMMON_PREFIX + 'courseware.enrollmentoptions'
 
@@ -45,3 +45,5 @@ class EnrollmentOptions extends Base {
 		return this.Items.FiveminuteEnrollment;
 	}
 }
+
+export default decorate(EnrollmentOptions, {with:[model]});

--- a/src/models/courses/Grade.js
+++ b/src/models/courses/Grade.js
@@ -1,4 +1,4 @@
-import {pluck} from '@nti/lib-commons';
+import {decorate,pluck} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import names from '../../mixins/CourseAndAssignmentNameResolving';
@@ -11,10 +11,6 @@ import Base from '../Base';
 const ENDS_IN_LETTER_REGEX = /\s[a-fiw-]$/i;
 
 
-export default
-@cacheClassInstances
-@model
-@mixin(names)
 class Grade extends Base {
 	static AllowWildDisconntectedInstances = true
 	static MimeType = [
@@ -171,6 +167,11 @@ class Grade extends Base {
 	}
 }
 
+export default decorate(Grade, {with:[
+	cacheClassInstances,
+	model,
+	mixin(names),
+]});
 
 
 function processValue (value) {

--- a/src/models/courses/GradeBookByAssignment.js
+++ b/src/models/courses/GradeBookByAssignment.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class GradeBookByAssignmentSummary extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'gradebook.gradebookbyassignmentsummary',
@@ -15,3 +15,5 @@ class GradeBookByAssignmentSummary extends Base {
 	}
 
 }
+
+export default decorate(GradeBookByAssignmentSummary, {with:[model]});

--- a/src/models/courses/GradeBookShell.js
+++ b/src/models/courses/GradeBookShell.js
@@ -1,8 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class GradeBookShell extends Base {
 	static MimeType = COMMON_PREFIX + 'gradebookshell'
 }
+
+export default decorate(GradeBookShell, {with:[model]});

--- a/src/models/courses/GradeBookUserSummary.js
+++ b/src/models/courses/GradeBookUserSummary.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
 
-export default
-@model
 class GradeBookUserSummary extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'gradebook.userassignmentsummary',
@@ -48,3 +48,5 @@ class GradeBookUserSummary extends Base {
 		return this.AvailableFinalGrade;
 	}
 }
+
+export default decorate(GradeBookUserSummary, {with:[model]});

--- a/src/models/courses/Instance.js
+++ b/src/models/courses/Instance.js
@@ -1,9 +1,9 @@
 import Url from 'url';
 import path from 'path';
 
+import {decorate,wait} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 import Logger from '@nti/util-logger';
-import {wait} from '@nti/lib-commons';
 
 import {
 	MEDIA_BY_OUTLINE_NODE,
@@ -48,9 +48,6 @@ const KnownActivitySorts = [
 	'LikeCount'
 ];
 
-export default
-@model
-@mixin(CourseIdentity, ContentTreeMixin)
 class Instance extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'courses.courseinstance',
@@ -718,6 +715,10 @@ class Instance extends Base {
 	}
 }
 
+export default decorate(Instance, {with:[
+	model,
+	mixin(CourseIdentity, ContentTreeMixin),
+]});
 
 //Private methods
 

--- a/src/models/courses/Invitation.js
+++ b/src/models/courses/Invitation.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CourseInvitation extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'courseware.courseinvitation',
@@ -16,3 +16,5 @@ class CourseInvitation extends Base {
 	}
 
 }
+
+export default decorate(CourseInvitation, {with:[model]});

--- a/src/models/courses/Invitations.js
+++ b/src/models/courses/Invitations.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CourseInvitations extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'courseware.courseinvitations'
@@ -14,3 +14,5 @@ class CourseInvitations extends Base {
 	}
 
 }
+
+export default decorate(CourseInvitations, {with:[model]});

--- a/src/models/courses/Outline.js
+++ b/src/models/courses/Outline.js
@@ -1,4 +1,4 @@
-import {isEmpty, updateValue} from '@nti/lib-commons';
+import {decorate,isEmpty, updateValue} from '@nti/lib-commons';
 
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
@@ -14,8 +14,6 @@ function getMaxDepthFrom (n) {
 		.reduce((max, depth) => Math.max(max, depth), 0);
 }
 
-export default
-@model
 class Outline extends Base {
 	static MimeType = COMMON_PREFIX + 'courses.courseoutline'
 
@@ -137,3 +135,5 @@ class Outline extends Base {
 		return flatten(this);
 	}
 }
+
+export default decorate(Outline, {with:[model]});

--- a/src/models/courses/OutlineNode.js
+++ b/src/models/courses/OutlineNode.js
@@ -1,5 +1,6 @@
 import url from 'url';
 
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 import {encodeForURI, isNTIID} from '@nti/lib-ntiids';
 import Logger from '@nti/util-logger';
@@ -17,9 +18,6 @@ import fallbackOverview from './_fallbacks.OverviewFromToC';
 
 const logger = Logger.get('models:courses:OutlineNode');
 
-export default
-@model
-@mixin(Publishable, ContentTreeMixin, ContentConstraints)
 class OutlineNode extends Outline {
 	static MimeType = [
 		COMMON_PREFIX + 'courses.courseoutlinenode',
@@ -214,6 +212,10 @@ class OutlineNode extends Outline {
 
 }
 
+export default decorate(OutlineNode, {with:[
+	model,
+	mixin(Publishable, ContentTreeMixin, ContentConstraints),
+]});
 
 function applyProgress ([content, progress]) {
 	if (!content || !progress) { return; }

--- a/src/models/courses/OutlineNodeProgress.js
+++ b/src/models/courses/OutlineNodeProgress.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class OutlineNodeProgress extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'courseoutlinenodeprogress',
@@ -19,3 +19,5 @@ class OutlineNodeProgress extends Base {
 		return this.Items[ntiid];
 	}
 }
+
+export default decorate(OutlineNodeProgress, {with:[model]});

--- a/src/models/courses/RosterEnrollmentSummary.js
+++ b/src/models/courses/RosterEnrollmentSummary.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import Base from '../Base';
 import {model, COMMON_PREFIX} from '../Registry';
 
-export default
-@model
 class RosterRecord extends Base {
 	static MimeType = COMMON_PREFIX + 'courses.rosterenrollmentsummary'
 
@@ -26,3 +26,5 @@ class RosterRecord extends Base {
 		return `${this.username}: ${this.user.displayName} (${this.user.displayType}) - enrolled: ${this.enrollmentStatus}`;
 	}
 }
+
+export default decorate(RosterRecord, {with:[model]});

--- a/src/models/courses/SharingScopes.js
+++ b/src/models/courses/SharingScopes.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class SharingScopes extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'courseinstancesharingscopes',
@@ -49,3 +49,5 @@ class SharingScopes extends Base {
 		}
 	}
 }
+
+export default decorate(SharingScopes, {with:[model]});

--- a/src/models/courses/activity/RecursiveStreamBucket.js
+++ b/src/models/courses/activity/RecursiveStreamBucket.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {threadThreadables} from '../../../utils/UserDataThreader';
 import {Parser as parse} from '../../../constants';
 import {model, COMMON_PREFIX} from '../../Registry';
@@ -5,8 +7,6 @@ import Base from '../../Base';
 
 const thread = (_, bucket, data) => threadThreadables(bucket[parse](data));
 
-export default
-@model
 class RecursiveStreamBucket extends Base {
 	static MimeType = COMMON_PREFIX + 'courseware.courserecursivestreambucket'
 
@@ -51,3 +51,5 @@ class RecursiveStreamBucket extends Base {
 		return Array.from(this).map(fn);
 	}
 }
+
+export default decorate(RecursiveStreamBucket, {with:[model]});

--- a/src/models/courses/activity/RecursiveStreamByBucket.js
+++ b/src/models/courses/activity/RecursiveStreamByBucket.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {Parser as parse} from '../../../constants';
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
@@ -6,8 +8,6 @@ const BY_MOST_RECENT = (a, b) => b.MostRecentTimestamp - a.MostRecentTimestamp;
 const sorted = (_, stream, data) => (stream[parse](data) || []).sort(BY_MOST_RECENT);
 
 
-export default
-@model
 class RecursiveStreamByBucket extends Base {
 	static MimeType = COMMON_PREFIX + 'courseware.courserecursivestreambybucket'
 
@@ -49,3 +49,5 @@ class RecursiveStreamByBucket extends Base {
 	}
 
 }
+
+export default decorate(RecursiveStreamByBucket, {with:[model]});

--- a/src/models/courses/lti/LTIConfiguredTool.js
+++ b/src/models/courses/lti/LTIConfiguredTool.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import { model, COMMON_PREFIX } from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class LTIConfiguredTool extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'ims.consumer.configuredtool',
@@ -18,3 +18,5 @@ class LTIConfiguredTool extends Base {
 		'secure_launch_url': { types: 'string' }
 	}
 }
+
+export default decorate(LTIConfiguredTool, {with:[model]});

--- a/src/models/courses/overview/Group.js
+++ b/src/models/courses/overview/Group.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Mixin as ContentTreeMixin} from '../../../content-tree';
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
-@mixin(ContentTreeMixin)
 class OverviewGroup extends Base {
 	static MimeType = COMMON_PREFIX + 'nticourseoverviewgroup'
 
@@ -28,3 +26,8 @@ class OverviewGroup extends Base {
 		return this.Items;
 	}
 }
+
+export default decorate(OverviewGroup, {with:[
+	model,
+	mixin(ContentTreeMixin),
+]});

--- a/src/models/courses/overview/LessonOverview.js
+++ b/src/models/courses/overview/LessonOverview.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Mixin as ContentTreeMixin} from '../../../content-tree';
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
-@mixin(ContentTreeMixin)
 class LessonOverview extends Base {
 	static MimeType = COMMON_PREFIX + 'ntilessonoverview'
 
@@ -26,3 +24,8 @@ class LessonOverview extends Base {
 		return this.Items;
 	}
 }
+
+export default decorate(LessonOverview, {with:[
+	model,
+	mixin(ContentTreeMixin),
+]});

--- a/src/models/courses/overview/VideoRoll.js
+++ b/src/models/courses/overview/VideoRoll.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Mixin as ContentTreeMixin} from '../../../content-tree';
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
-@mixin(ContentTreeMixin)
 class VideoRoll extends Base {
 	static MimeType = COMMON_PREFIX + 'videoroll'
 
@@ -19,3 +17,8 @@ class VideoRoll extends Base {
 		return this.Items;
 	}
 }
+
+export default decorate(VideoRoll, {with:[
+	model,
+	mixin(ContentTreeMixin),
+]});

--- a/src/models/courses/scorm/SCORMContentInfo.js
+++ b/src/models/courses/scorm/SCORMContentInfo.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import Completable from '../../../mixins/Completable';
@@ -15,9 +16,6 @@ const RUNNING = 'running';
 const ERROR = 'error';
 const FINISHED = 'finished';
 
-export default
-@model
-@mixin(Completable)
 class SCORMContentInfo extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'scorm.scormcontentinfo'
@@ -85,3 +83,8 @@ class SCORMContentInfo extends Base {
 		return createPollingTask(poll, POLL_INTERVAL, POLL_STEP_OFF);
 	}
 }
+
+export default decorate(SCORMContentInfo, {with:[
+	model,
+	mixin(Completable),
+]});

--- a/src/models/courses/scorm/SCORMCourseMetadata.js
+++ b/src/models/courses/scorm/SCORMCourseMetadata.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import { model, COMMON_PREFIX } from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class SCORMCourseMetadata extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'courseware_scorm.scormcoursemetadata',
@@ -13,3 +13,5 @@ class SCORMCourseMetadata extends Base {
 		'scorm_id': { type: 'string', name: 'scormId' }
 	}
 }
+
+export default decorate(SCORMCourseMetadata, {with:[model]});

--- a/src/models/courses/scorm/SCORMInstance.js
+++ b/src/models/courses/scorm/SCORMInstance.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import { model, COMMON_PREFIX } from '../../Registry';
 import Instance from '../Instance';
 
-export default
-@model
 class ScormInstance extends Instance {
 	static MimeType = [
 		COMMON_PREFIX + 'courses.scormcourseinstance',
@@ -19,3 +19,5 @@ class ScormInstance extends Instance {
 		return this.Metadata.getLink('LaunchSCORM');
 	}
 }
+
+export default decorate(ScormInstance, {with:[model]});

--- a/src/models/courses/scorm/SCORMReference.js
+++ b/src/models/courses/scorm/SCORMReference.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class SCORMReference extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'scormcontentref'
@@ -24,3 +24,5 @@ class SCORMReference extends Base {
 	completedSuccessfully (...args) { return this.ScormContentInfo ? this.ScormContentInfo.completedSuccessfully(...args) : null; }
 	completedUnsuccessfully (...args) { return this.ScormContentInfo ? this.ScormContentInfo.completedUnsuccessfully(...args) : null; }
 }
+
+export default decorate(SCORMReference, {with:[model]});

--- a/src/models/credit/BaseCredit.js
+++ b/src/models/credit/BaseCredit.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class BaseCredit extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'credit.basecredit'
@@ -22,3 +22,5 @@ class BaseCredit extends Base {
 	getAwardedDate () {} //implemented by awarded_date date field.
 
 }
+
+export default decorate(BaseCredit, {with:[model]});

--- a/src/models/credit/CourseAwardableCredit.js
+++ b/src/models/credit/CourseAwardableCredit.js
@@ -1,12 +1,14 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import BaseCredit from './BaseCredit';
 
-export default
-@model
 class CourseAwardableCredit extends BaseCredit {
 	static MimeType = [
 		COMMON_PREFIX + 'credit.courseawardablecredit'
 	]
 
 }
+
+export default decorate(CourseAwardableCredit, {with:[model]});

--- a/src/models/credit/CourseAwardedCredit.js
+++ b/src/models/credit/CourseAwardedCredit.js
@@ -1,12 +1,14 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import BaseCredit from './BaseCredit';
 
-export default
-@model
 class CourseAwardedCredit extends BaseCredit {
 	static MimeType = [
 		COMMON_PREFIX + 'credit.courseawardedcredit'
 	]
 
 }
+
+export default decorate(CourseAwardedCredit, {with:[model]});

--- a/src/models/credit/CreditDefinition.js
+++ b/src/models/credit/CreditDefinition.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class CreditDefinition extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'credit.creditdefinition'
@@ -15,3 +15,5 @@ class CreditDefinition extends Base {
 	}
 
 }
+
+export default decorate(CreditDefinition, {with:[model]});

--- a/src/models/credit/UserAwardedCredit.js
+++ b/src/models/credit/UserAwardedCredit.js
@@ -1,12 +1,14 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import BaseCredit from './BaseCredit';
 
-export default
-@model
 class UserAwardedCredit extends BaseCredit {
 	static MimeType = [
 		COMMON_PREFIX + 'credit.userawardedcredit'
 	]
 
 }
+
+export default decorate(UserAwardedCredit, {with:[model]});

--- a/src/models/entities/Community.js
+++ b/src/models/entities/Community.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import Stream from '../../stores/Stream';
 import { Service } from '../../constants';
 import {model, COMMON_PREFIX} from '../Registry';
@@ -15,8 +17,6 @@ const KnownActivitySorts = [
 	'LikeCount'
 ];
 
-export default
-@model
 class Community extends Entity {
 	static MimeType = COMMON_PREFIX + 'community'
 
@@ -294,9 +294,11 @@ class Community extends Entity {
 	async delete () {
 		this.emit('deleting');
 		const resp = await super.delete('delete');
-		
+
 		this.emit('deleted');
 
 		return resp;
 	}
 }
+
+export default decorate(Community, {with:[model]});

--- a/src/models/entities/DynamicFriendsList.js
+++ b/src/models/entities/DynamicFriendsList.js
@@ -1,11 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import { Service, DELETED } from '../../constants';
 import Stream from '../../stores/Stream';
 import {model, COMMON_PREFIX} from '../Registry';
 
 import FriendsList from './FriendsList';
 
-export default
-@model
 class DynamicFriendsList extends FriendsList {
 	static MimeType = COMMON_PREFIX + 'dynamicfriendslist'
 
@@ -125,3 +125,5 @@ class DynamicFriendsList extends FriendsList {
 		return this.getDiscussionBoard().then(x => x.getContents());
 	}
 }
+
+export default decorate(DynamicFriendsList, {with:[model]});

--- a/src/models/entities/FriendsList.js
+++ b/src/models/entities/FriendsList.js
@@ -1,4 +1,4 @@
-import {pluck} from '@nti/lib-commons';
+import {decorate,pluck} from '@nti/lib-commons';
 
 import {model, COMMON_PREFIX} from '../Registry';
 
@@ -7,8 +7,6 @@ import Entity from './Entity';
 
 const getID = e => typeof e === 'object' ? e.getID() : e;
 
-export default
-@model
 class FriendsList extends Entity {
 	static MimeType = COMMON_PREFIX + 'friendslist'
 
@@ -186,3 +184,5 @@ class FriendsList extends Entity {
 
 	getID () { return this.ID; }
 }
+
+export default decorate(FriendsList, {with:[model]});

--- a/src/models/entities/PresenceInfo.js
+++ b/src/models/entities/PresenceInfo.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import Base from '../Base';
 import {model, COMMON_PREFIX} from '../Registry';
 
 
-export default
-@model
 class PresenceInfo extends Base {
 	static MimeType = COMMON_PREFIX + 'presenceinfo'
 
@@ -37,3 +37,5 @@ class PresenceInfo extends Base {
 		return show;
 	}
 }
+
+export default decorate(PresenceInfo, {with:[model]});

--- a/src/models/entities/SuggestedContacts.js
+++ b/src/models/entities/SuggestedContacts.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class SuggestedContacts extends Base {
 	static MimeType = COMMON_PREFIX + 'suggestedcontacts'
 
@@ -17,3 +17,5 @@ class SuggestedContacts extends Base {
 		console.debug('TODO: SuggestedContacts:', data); //eslint-disable-line no-console
 	}
 }
+
+export default decorate(SuggestedContacts, {with:[model]});

--- a/src/models/entities/User.js
+++ b/src/models/entities/User.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import Achievements from '../../stores/Achievements';
 import Stream from '../../stores/Stream';
 import { Service, TOS_NOT_ACCEPTED} from '../../constants';
@@ -28,8 +30,6 @@ function cleanData (data) {
 	};
 }
 
-export default
-@model
 class User extends Entity {
 	static MimeType = COMMON_PREFIX + 'user'
 
@@ -283,3 +283,5 @@ class User extends Entity {
 		return excludeGroups ? list.filter(ONLY_COMMUNITIES) : list;
 	}
 }
+
+export default decorate(User, {with:[model]});

--- a/src/models/forums/Blog.js
+++ b/src/models/forums/Blog.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Board from './Board';
 
-export default
-@model
 class Blog extends Board {
 	static MimeType = COMMON_PREFIX + 'forums.personalblog'
 
@@ -15,3 +15,5 @@ class Blog extends Board {
 	}
 
 }
+
+export default decorate(Blog, {with:[model]});

--- a/src/models/forums/BlogEntry.js
+++ b/src/models/forums/BlogEntry.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {isNTIID} from '@nti/lib-ntiids';
 
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Topic from './Topic';
 
-
-export default
-@model
 class BlogEntry extends Topic {
 	static MimeType = COMMON_PREFIX + 'forums.personalblogentry'
 
@@ -86,3 +84,5 @@ class BlogEntry extends Topic {
 		}
 	}
 }
+
+export default decorate(BlogEntry, {with:[model]});

--- a/src/models/forums/Board.js
+++ b/src/models/forums/Board.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import GetContents from '../../mixins/GetContents';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(GetContents)
 class Board extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'forums.board',
@@ -35,3 +33,8 @@ class Board extends Base {
 		return forum;
 	}
 }
+
+export default decorate(Board, {with:[
+	model,
+	mixin(GetContents),
+]});

--- a/src/models/forums/Comment.js
+++ b/src/models/forums/Comment.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import Threadable from '../../mixins/Threadable';
@@ -6,9 +7,6 @@ import {model, COMMON_PREFIX} from '../Registry';
 
 import Post from './Post';
 
-export default
-@model
-@mixin(Threadable, DiscussionInterface)
 class Comment extends Post {
 	static MimeType = [
 		COMMON_PREFIX + 'forums.comment',
@@ -102,3 +100,8 @@ class Comment extends Post {
 		return discussion;
 	}
 }
+
+export default decorate(Comment, {with:[
+	model,
+	mixin(Threadable, DiscussionInterface),
+]});

--- a/src/models/forums/Forum.js
+++ b/src/models/forums/Forum.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Service, Parser as parse} from '../../constants';
@@ -17,9 +18,6 @@ const KnownSorts = [
 	'LikeCount'
 ];
 
-export default
-@model
-@mixin(GetContents)
 class Forum extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'forums.forum',
@@ -130,3 +128,8 @@ class Forum extends Base {
 		parent.emit('change');
 	}
 }
+
+export default decorate(Forum, {with:[
+	model,
+	mixin(GetContents),
+]});

--- a/src/models/forums/Post.js
+++ b/src/models/forums/Post.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 // import Editable from '../../mixins/Editable'; //Base already mixes in Editable
@@ -6,9 +7,6 @@ import DiscussionInterface from '../../mixins/DiscussionInterface';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(Likable, DiscussionInterface)
 class Post extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'forums.post',
@@ -30,3 +28,8 @@ class Post extends Base {
 		return this.parent().getRawSharedWith();
 	}
 }
+
+export default decorate(Post, {with:[
+	model,
+	mixin(Likable, DiscussionInterface)
+]});

--- a/src/models/forums/Topic.js
+++ b/src/models/forums/Topic.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Service} from '../../constants';
@@ -10,9 +11,6 @@ import DiscussionInterface from '../../mixins/DiscussionInterface';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-@mixin(GetContents, Likable, Pinnable, Flaggable, DiscussionInterface)
 class Topic extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'forums.topic',
@@ -137,3 +135,8 @@ class Topic extends Base {
 		return discussion;
 	}
 }
+
+export default decorate(Topic, {with:[
+	model,
+	mixin(GetContents, Likable, Pinnable, Flaggable, DiscussionInterface),
+]});

--- a/src/models/forums/UserTopicParticipationContext.js
+++ b/src/models/forums/UserTopicParticipationContext.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class UserTopicParticipationContext extends Base {
 	static MimeType = COMMON_PREFIX + 'forums.usertopicparticipationcontext'
 
@@ -13,3 +13,5 @@ class UserTopicParticipationContext extends Base {
 	}
 
 }
+
+export default decorate(UserTopicParticipationContext, {with:[model]});

--- a/src/models/forums/UserTopicParticipationSummary.js
+++ b/src/models/forums/UserTopicParticipationSummary.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class UserTopicParticipationSummary extends Base {
 	static MimeType = COMMON_PREFIX + 'forums.usertopicparticipationsummary'
 
@@ -15,3 +15,5 @@ class UserTopicParticipationSummary extends Base {
 	}
 
 }
+
+export default decorate(UserTopicParticipationSummary, {with:[model]});

--- a/src/models/integrations/goto-webinar/Integration.js
+++ b/src/models/integrations/goto-webinar/Integration.js
@@ -1,11 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Integration from '../Integration';
 
 const DISCONNECTED_MIMETYPE = COMMON_PREFIX + 'integration.gotowebinarintegration';
 const CONNECTED_MIMETYPE = COMMON_PREFIX + 'integration.gotowebinarauthorizedintegration';
 
-export default
-@model
 class GotoWebinar extends Integration {
 	static MimeType = [
 		DISCONNECTED_MIMETYPE,
@@ -68,3 +68,5 @@ class GotoWebinar extends Integration {
 		}
 	}
 }
+
+export default decorate(GotoWebinar, {with:[model]});

--- a/src/models/integrations/goto-webinar/Webinar.js
+++ b/src/models/integrations/goto-webinar/Webinar.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class Webinar extends Base {
 	static MimeType = COMMON_PREFIX + 'webinar'
 
@@ -97,3 +97,5 @@ class Webinar extends Base {
 		return (x => !x || (x.getStartTime() <= date && x.getEndTime() <= date))(this.getNearestSession(date));
 	}
 }
+
+export default decorate(Webinar, {with:[model]});

--- a/src/models/integrations/goto-webinar/WebinarAsset.js
+++ b/src/models/integrations/goto-webinar/WebinarAsset.js
@@ -1,12 +1,10 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 import Completable from '../../../mixins/Completable';
 
-export default
-@model
-@mixin(Completable)
 class WebinarAsset extends Base {
 	static MimeType = COMMON_PREFIX + 'webinarasset'
 
@@ -19,3 +17,8 @@ class WebinarAsset extends Base {
 		'icon':         { type: 'string' }
 	}
 }
+
+export default decorate(WebinarAsset, {with:[
+	model,
+	mixin(Completable),
+]});

--- a/src/models/integrations/goto-webinar/WebinarSession.js
+++ b/src/models/integrations/goto-webinar/WebinarSession.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
-export default
-@model
 class WebinarSession extends Base {
 	static MimeType = COMMON_PREFIX + 'webinarsession'
 
@@ -15,3 +15,5 @@ class WebinarSession extends Base {
 	getStartTime () { } //implemented by startTime date field.
 	getEndTime () { } //implemented by endTime date field.
 }
+
+export default decorate(WebinarSession, {with:[model]});

--- a/src/models/integrations/stripe/Integration.js
+++ b/src/models/integrations/stripe/Integration.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../../Registry';
 import Base from '../../Base';
 
@@ -5,8 +7,6 @@ const ConnectRel = 'connect_stripe_account';
 const DisconnectRel = 'disconnect_stripe_account';
 const AccountInfoRel = 'account_info';
 
-export default
-@model
 class StripeIntegration extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'integration.stripeintegration'
@@ -39,7 +39,7 @@ class StripeIntegration extends Base {
 
 		return info && info.StripeAccountID;
 	}
-	
+
 	async disconnect () {
 		await this.requestLink(DisconnectRel, 'delete');
 		await this.sync();
@@ -56,3 +56,5 @@ class StripeIntegration extends Base {
 		}
 	}
 }
+
+export default decorate(StripeIntegration, {with:[model]});

--- a/src/models/invitations/SiteAdminInvitation.js
+++ b/src/models/invitations/SiteAdminInvitation.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import BaseSiteInvitation from './BaseSiteInvitation';
 
-export default
-@model
 class SiteAdminInvitation extends BaseSiteInvitation {
 	static MimeType = COMMON_PREFIX + 'siteadmininvitation'
 
@@ -12,3 +12,5 @@ class SiteAdminInvitation extends BaseSiteInvitation {
 	}
 
 }
+
+export default decorate(SiteAdminInvitation, {with:[model]});

--- a/src/models/invitations/SiteInvitation.js
+++ b/src/models/invitations/SiteInvitation.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import BaseSiteInvitation from './BaseSiteInvitation';
 
-export default
-@model
 class SiteInvitation extends BaseSiteInvitation {
 	static MimeType = COMMON_PREFIX + 'siteinvitation'
 
@@ -12,3 +12,5 @@ class SiteInvitation extends BaseSiteInvitation {
 	}
 
 }
+
+export default decorate(SiteInvitation, {with:[model]});

--- a/src/models/media/MediaSource.js
+++ b/src/models/media/MediaSource.js
@@ -1,3 +1,5 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
@@ -7,8 +9,6 @@ import MediaSourceFactory from './MediaSourceFactory';
 const resolver = Symbol('Resolver');
 const resolveCanAccess = Symbol('Resolve Can Access');
 
-export default
-@model
 class MediaSource extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'ntivideosource',
@@ -46,7 +46,7 @@ class MediaSource extends Base {
 		return !!this.meta.failure;
 	}
 
-	
+
 	getResolver () {
 		return this[resolver] || (
 			this[resolver] = MetaDataResolver.from(this)
@@ -95,3 +95,5 @@ class MediaSource extends Base {
 		return this.getProperty('duration');
 	}
 }
+
+export default decorate(MediaSource, {with:[model]});

--- a/src/models/media/Slide.js
+++ b/src/models/media/Slide.js
@@ -1,4 +1,4 @@
-import {URL} from '@nti/lib-commons';
+import {decorate,URL} from '@nti/lib-commons';
 
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
@@ -7,8 +7,6 @@ const getRoot = x => (x ? x.root : x) || '/missing-root/';
 const findRoot = p => getRoot((p && p.parent) ? p.parent('root') : null);
 const resolve = (s, p, path) => URL.resolve(findRoot(p), path);
 
-export default
-@model
 class Slide extends Base {
 	static MimeType = COMMON_PREFIX + 'slide'
 
@@ -22,3 +20,5 @@ class Slide extends Base {
 		'slidevideoend':   { type: 'number?', name: 'endTime'   },
 	}
 }
+
+export default decorate(Slide, {with:[model]});

--- a/src/models/media/SlideDeck.js
+++ b/src/models/media/SlideDeck.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin/*, readonly*/} from '@nti/lib-decorators';
 
 import UserDataStore from '../../stores/UserData';
@@ -10,9 +11,6 @@ import Base from '../Base';
 
 const UserData = Symbol('UserData');
 
-export default
-@model
-@mixin({/*@readonly*/ isSlideDeck: true})
 class SlideDeck extends Base {
 	[Symbol.iterator] = () => this.Slides[Symbol.iterator]();
 
@@ -39,3 +37,8 @@ class SlideDeck extends Base {
 		return Promise.resolve(store); //in the future, this may need to be async...
 	}
 }
+
+export default decorate(SlideDeck, {with:[
+	model,
+	mixin({/*@readonly*/ isSlideDeck: true}),
+]});

--- a/src/models/media/SlideVideo.js
+++ b/src/models/media/SlideVideo.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class SlideVideo extends Base {
 	static MimeType = COMMON_PREFIX + 'ntislidevideo'
 
@@ -16,3 +16,5 @@ class SlideVideo extends Base {
 		'video-ntiid':   { type: 'string', name: 'videoId'     },
 	}
 }
+
+export default decorate(SlideVideo, {with:[model]});

--- a/src/models/media/Timeline.js
+++ b/src/models/media/Timeline.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class Timeline extends Base {
 	static MimeType = COMMON_PREFIX + 'ntitimeline'
 
@@ -16,3 +16,5 @@ class Timeline extends Base {
 	}
 
 }
+
+export default decorate(Timeline, {with:[model]});

--- a/src/models/media/Transcript.js
+++ b/src/models/media/Transcript.js
@@ -1,11 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {Parent} from '../../constants';
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
 const EXISTING_TRANSCRIPT = ' A Transcript already exists';
 
-export default
-@model
 class Transcript extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'ntitranscript'
@@ -48,3 +48,5 @@ class Transcript extends Base {
 		this.emit('changed');
 	}
 }
+
+export default decorate(Transcript, {with:[model]});

--- a/src/models/media/Video.js
+++ b/src/models/media/Video.js
@@ -1,4 +1,4 @@
-import { isEmpty } from '@nti/lib-commons';
+import {decorate, isEmpty } from '@nti/lib-commons';
 import { mixin } from '@nti/lib-decorators';
 
 import Completable from '../../mixins/Completable';
@@ -36,7 +36,7 @@ class MediaSourceUtil {
 
 			if (source && source[method]) {
 				const value = await source[method]();
-				
+
 				if (source.hasResolverFailure && sources.length > sourceIndex + 1) {
 					return next(value);
 				}
@@ -52,9 +52,6 @@ class MediaSourceUtil {
 	}
 }
 
-export default
-@model
-@mixin(Completable, Pages)
 class Video extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'ntivideo',
@@ -200,3 +197,8 @@ class Video extends Base {
 		return updatedTranscript;
 	}
 }
+
+export default decorate(Video, {with:[
+	model,
+	mixin(Completable, Pages),
+]});

--- a/src/models/media/VideoRef.js
+++ b/src/models/media/VideoRef.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class VideoRef extends Base {
 	static MimeType = COMMON_PREFIX + 'ntivideoref'
 
@@ -12,3 +12,5 @@ class VideoRef extends Base {
 		console.debug('What is this?', this); //eslint-disable-line no-console
 	}
 }
+
+export default decorate(VideoRef, {with:[model]});

--- a/src/models/profile/Badge.js
+++ b/src/models/profile/Badge.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class Badge extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'badge',
@@ -30,3 +30,5 @@ class Badge extends Base {
 		'tags':        { type: 'string[]' },
 	}
 }
+
+export default decorate(Badge, {with:[model]});

--- a/src/models/profile/BadgeIssuer.js
+++ b/src/models/profile/BadgeIssuer.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class BadgeIssuer extends Base {
 	static MimeType = COMMON_PREFIX + 'openbadges.issuer'
 
@@ -16,3 +16,5 @@ class BadgeIssuer extends Base {
 		'url':            { type: 'string' },
 	}
 }
+
+export default decorate(BadgeIssuer, {with:[model]});

--- a/src/models/profile/EducationalExperience.js
+++ b/src/models/profile/EducationalExperience.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class EducationalExperience extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'profile.educationalexperience',
@@ -18,3 +18,5 @@ class EducationalExperience extends Base {
 		'startYear':   { type: 'number'                 },
 	}
 }
+
+export default decorate(EducationalExperience, {with:[model]});

--- a/src/models/profile/ProfessionalPosition.js
+++ b/src/models/profile/ProfessionalPosition.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class ProfessionalPosition extends Base {
 	static MimeType = COMMON_PREFIX + 'profile.professionalposition'
 
@@ -15,3 +15,5 @@ class ProfessionalPosition extends Base {
 		'title':       { type: 'string'                 },
 	}
 }
+
+export default decorate(ProfessionalPosition, {with:[model]});

--- a/src/models/reports/BaseReport.js
+++ b/src/models/reports/BaseReport.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
-class InstructorReport extends Base {
+class BaseReport extends Base {
 	static MimeType = COMMON_PREFIX + 'reports.basereport'
 
 	static Fields = {
@@ -14,3 +14,5 @@ class InstructorReport extends Base {
 		'contexts':        {type: 'object'}
 	}
 }
+
+export default decorate(BaseReport, {with:[model]});

--- a/src/models/reports/InstructorReport.js
+++ b/src/models/reports/InstructorReport.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Base from './BaseReport';
 
-export default
-@model
 class InstructorReport extends Base {
 	static MimeType = COMMON_PREFIX + 'courseware_reports.instructorreport'
 }
+
+export default decorate(InstructorReport, {with:[model]});

--- a/src/models/store/GiftPurchaseAttempt.js
+++ b/src/models/store/GiftPurchaseAttempt.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import PurchaseAttempt from './PurchaseAttempt';
 
 
-export default
-@model
 class GiftPurchaseAttempt extends PurchaseAttempt {
 	static MimeType = COMMON_PREFIX + 'store.giftpurchaseattempt'
 
@@ -18,3 +18,5 @@ class GiftPurchaseAttempt extends PurchaseAttempt {
 	}
 
 }
+
+export default decorate(GiftPurchaseAttempt, {with:[model]});

--- a/src/models/store/PricedItem.js
+++ b/src/models/store/PricedItem.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class PricedItem extends Base {
 	static MimeType = COMMON_PREFIX + 'store.priceditem'
 
@@ -15,3 +15,5 @@ class PricedItem extends Base {
 		'Quantity':      { type: 'number', name: 'quantity'      },
 	}
 }
+
+export default decorate(PricedItem, {with:[model]});

--- a/src/models/store/PricingResults.js
+++ b/src/models/store/PricingResults.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
 
-export default
-@model
 class PricingResults extends Base {
 	static MimeType = COMMON_PREFIX + 'store.pricingresults'
 
@@ -15,3 +15,5 @@ class PricingResults extends Base {
 		'TotalNonDiscountedPrice':    { type: 'number'                    },
 	}
 }
+
+export default decorate(PricingResults, {with:[model]});

--- a/src/models/store/Purchasable.js
+++ b/src/models/store/Purchasable.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
 const StripeConnectKey = Symbol('StripeConnectKey');
 
-export default
-@model
 class Purchasable extends Base {
 	static MimeType = COMMON_PREFIX + 'store.purchasable'
 
@@ -32,3 +32,5 @@ class Purchasable extends Base {
 		return this[StripeConnectKey];
 	}
 }
+
+export default decorate(Purchasable, {with:[model]});

--- a/src/models/store/PurchasableCourse.js
+++ b/src/models/store/PurchasableCourse.js
@@ -1,9 +1,9 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Purchasable from './Purchasable';
 
-export default
-@model
 class PurchasableCourse extends Purchasable {
 	static MimeType = COMMON_PREFIX + 'store.purchasablecourse'
 
@@ -12,3 +12,5 @@ class PurchasableCourse extends Purchasable {
 		'ID': { type: 'string' }
 	}
 }
+
+export default decorate(PurchasableCourse, {with:[model]});

--- a/src/models/store/PurchasableCourseChoiceBundle.js
+++ b/src/models/store/PurchasableCourseChoiceBundle.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import Purchasable from './Purchasable';
 
-export default
-@model
 class PurchasableCourseChoiceBundle extends Purchasable {
 	static MimeType = COMMON_PREFIX + 'store.purchasablecoursechoicebundle'
 }
+
+export default decorate(PurchasableCourseChoiceBundle, {with:[model]});

--- a/src/models/store/PurchasableVendorInfo.js
+++ b/src/models/store/PurchasableVendorInfo.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class PurchasableVendorInfo extends Base {
 	static MimeType = COMMON_PREFIX + 'store.purchasablevendorinfo'
 
@@ -22,3 +22,5 @@ class PurchasableVendorInfo extends Base {
 	getEndDate () {} //implemented by the date Field type
 	getStartDate () {} //implemented by the date Field type
 }
+
+export default decorate(PurchasableVendorInfo, {with:[model]});

--- a/src/models/store/PurchaseAttempt.js
+++ b/src/models/store/PurchaseAttempt.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class PurchaseAttempt extends Base {
 	static MimeType = COMMON_PREFIX + 'store.purchaseattempt'
 
@@ -29,3 +29,5 @@ class PurchaseAttempt extends Base {
 	getEndTime () {} //implemented by the date Field type
 	getStartTime () {} //implemented by the date Field type
 }
+
+export default decorate(PurchaseAttempt, {with:[model]});

--- a/src/models/store/StripeConnectKey.js
+++ b/src/models/store/StripeConnectKey.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class StripeConnectKey extends Base {
 	static MimeType = [
 		COMMON_PREFIX + 'store.stripeconnectkey',
@@ -17,3 +17,5 @@ class StripeConnectKey extends Base {
 		'StripeUserID': { type: 'string'  },
 	}
 }
+
+export default decorate(StripeConnectKey, {with:[model]});

--- a/src/models/store/StripeCoupon.js
+++ b/src/models/store/StripeCoupon.js
@@ -1,8 +1,8 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
-export default
-@model
 class StripeCoupon extends Base {
 	static MimeType = COMMON_PREFIX + 'store.stripecoupon'
 
@@ -20,3 +20,5 @@ class StripeCoupon extends Base {
 
 	getCode () { return this.ID; }
 }
+
+export default decorate(StripeCoupon, {with:[model]});

--- a/src/models/store/StripePricedPurchasable.js
+++ b/src/models/store/StripePricedPurchasable.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
 import Coupon from './StripeCoupon';
 
-export default
-@model
 class StripePricedPurchasable extends Base {
 	static MimeType = COMMON_PREFIX + 'store.stripepricedpurchasable'
 
@@ -19,3 +19,5 @@ class StripePricedPurchasable extends Base {
 		'Provider':           { type: 'string'                              },
 	}
 }
+
+export default decorate(StripePricedPurchasable, {with:[model]});

--- a/src/models/store/StripePurchaseItem.js
+++ b/src/models/store/StripePurchaseItem.js
@@ -1,10 +1,10 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 import Base from '../Base';
 
 const Items = Symbol('Items');
 
-export default
-@model
 class StripePurchaseItem extends Base {
 	static MimeType = COMMON_PREFIX + 'store.stripepurchaseitem'
 
@@ -15,3 +15,5 @@ class StripePurchaseItem extends Base {
 		'Quantity': { type: 'number',  name: 'quantity' },
 	}
 }
+
+export default decorate(StripePurchaseItem, {with:[model]});

--- a/src/models/store/StripePurchaseOrder.js
+++ b/src/models/store/StripePurchaseOrder.js
@@ -1,9 +1,11 @@
+import {decorate} from '@nti/lib-commons';
+
 import {model, COMMON_PREFIX} from '../Registry';
 
 import StripePurchaseItem from './StripePurchaseItem';
 
-export default
-@model
 class StripePurchaseOrder extends StripePurchaseItem {
 	static MimeType = COMMON_PREFIX + 'store.stripepurchaseorder'
 }
+
+export default decorate(StripePurchaseOrder, {with:[model]});

--- a/src/stores/Achievements.js
+++ b/src/stores/Achievements.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 import Logger from '@nti/util-logger';
 
@@ -10,8 +11,6 @@ import {parseListFn} from '../models/Parser';
 
 const logger = Logger.get('store:Achievements');
 
-export default
-@mixin(Pendability)
 class Achievements extends EventEmitter {
 
 	constructor (service, owner, data) {
@@ -73,3 +72,5 @@ class Achievements extends EventEmitter {
 		return this.waitForPending().then(()=> this.earnable);
 	}
 }
+
+export default decorate(Achievements, {with:[mixin(Pendability)]});

--- a/src/stores/AssignmentSummary.js
+++ b/src/stores/AssignmentSummary.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {getPrivate} from '../utils/private';
@@ -16,8 +17,6 @@ const OPPOSITE_FILTER = {
 	Open: 'forcredit'
 };
 
-export default
-@mixin(Paged)
 class AssignmentSummary extends Stream {
 
 	constructor (...args) {
@@ -85,3 +84,5 @@ class AssignmentSummary extends Stream {
 	get filter () { return this.options.filter; }
 	getFilter () { return this.filter; }
 }
+
+export default decorate(AssignmentSummary, {with:[mixin(Paged)]});

--- a/src/stores/Contacts.js
+++ b/src/stores/Contacts.js
@@ -2,7 +2,7 @@ import url from 'url';
 import EventEmitter from 'events';
 
 import Logger from '@nti/util-logger';
-import { Promises } from '@nti/lib-commons';
+import {decorate, Promises } from '@nti/lib-commons';
 import { mixin } from '@nti/lib-decorators';
 import {v4 as uuid} from 'uuid';
 
@@ -54,8 +54,6 @@ export function getNewListData (name, isDynamic, MimeType, context, friends = []
 }
 
 
-export default
-@mixin(Pendability)
 class Contacts extends EventEmitter {
 
 	/**
@@ -330,3 +328,5 @@ class Contacts extends EventEmitter {
 		}
 	}
 }
+
+export default decorate(Contacts, {with:[mixin(Pendability)]});

--- a/src/stores/CourseRoster.js
+++ b/src/stores/CourseRoster.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 
 import {Service} from '../constants';
@@ -34,8 +35,6 @@ class RosterRecord extends Base {
 	}
 }
 
-export default
-@mixin(Paged)
 class CourseRosterStream extends Stream {
 
 	constructor (...args) {
@@ -66,3 +65,5 @@ class CourseRosterStream extends Stream {
 		this.nextBatch();
 	}
 }
+
+export default decorate(CourseRosterStream, {with:[mixin(Paged)]});

--- a/src/stores/EntityStore.js
+++ b/src/stores/EntityStore.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 import Logger from '@nti/util-logger';
 
@@ -12,8 +13,6 @@ import {parseListFn} from '../models/Parser';
 const logger = Logger.get('store:EntityStore');
 const DATA = Symbol();
 
-export default
-@mixin(Pendability)
 class EntityStore extends EventEmitter {
 
 	/**
@@ -90,3 +89,5 @@ class EntityStore extends EventEmitter {
 		};
 	}
 }
+
+export default decorate(EntityStore, {with:[mixin(Pendability)]});

--- a/src/stores/GradeBookSummary.js
+++ b/src/stores/GradeBookSummary.js
@@ -1,3 +1,4 @@
+import {decorate} from '@nti/lib-commons';
 import {mixin} from '@nti/lib-decorators';
 import Logger from '@nti/util-logger';
 
@@ -35,8 +36,6 @@ function setFilter (instance, scope = instance.scopeFilter, category = instance.
 	instance.loadPage(1);
 }
 
-export default
-@mixin(Paged)
 class GradeBookSummary extends Stream {
 
 	constructor (service, owner, href, options, ...args) {
@@ -129,3 +128,5 @@ class GradeBookSummary extends Stream {
 	get scopeFilter () { return getPrivate(this).scopeFilter; }
 	get categoryFilter () { return getPrivate(this).categoryFilter; }
 }
+
+export default decorate(GradeBookSummary, {with:[mixin(Paged)]});

--- a/src/stores/Service.js
+++ b/src/stores/Service.js
@@ -3,7 +3,7 @@ import EventEmitter from 'events';
 import Logger from '@nti/util-logger';
 import {mixin} from '@nti/lib-decorators';
 import { isNTIID } from '@nti/lib-ntiids';
-import { URL, wait } from '@nti/lib-commons';
+import {decorate, URL, wait } from '@nti/lib-commons';
 import LRU from 'lru-cache';
 
 import { parse } from '../models/Parser';
@@ -64,10 +64,6 @@ function hideCurrentProperties (o) {
 	}
 }
 
-
-
-export default
-@mixin(Pendability, InstanceCacheContainer)
 class ServiceDocument extends EventEmitter {
 
 	constructor (json, server, context) {
@@ -953,3 +949,5 @@ class ServiceDocument extends EventEmitter {
 		return promise;
 	}
 }
+
+export default decorate(ServiceDocument, {with:[mixin(Pendability, InstanceCacheContainer)]});

--- a/src/stores/UserData.js
+++ b/src/stores/UserData.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 
+import {decorate} from '@nti/lib-commons';
 import Logger from '@nti/util-logger';
 import {mixin} from '@nti/lib-decorators';
 
@@ -20,9 +21,6 @@ export function binId (i, rootId) {
 	return id !== rootId ? binId : 'root';
 }
 
-
-export default
-@mixin(Pendability)
 class UserData extends EventEmitter {
 
 	constructor (service, rootContainerId, source) {
@@ -201,3 +199,5 @@ class UserData extends EventEmitter {
 			});
 	}
 }
+
+export default decorate(UserData, {with:[mixin(Pendability)]});


### PR DESCRIPTION
This removes decorator syntax from the library. 

Since it runs on both node and client, I want to avoid transpiling for node. And decorators do not look like they're going to advance anytime soon.