### PR TITLE
emit course drop events

### DIFF
--- a/src/stores/Enrollment.js
+++ b/src/stores/Enrollment.js
@@ -37,7 +37,7 @@ export default class Enrollment extends EventEmitter {
 		const course = await this.getCourse(courseId);
 
 		if (!course.PreferredAccess) {
-			return Promise.reject(new Error('Not Enrolled?'));
+			throw new Error('Not Enrolled?');
 		}
 
 		let error;


### PR DESCRIPTION
Turns the Enrollment store into an event emitter to facilitate UI feedback when dropping courses.

See companion [PR in web.course](https://github.com/NextThought/nti.web.course/pull/202).

